### PR TITLE
Add missing applicationId for applicationKey

### DIFF
--- a/CDFModule/Public/func_Get-GitHubConfigApplication.ps1
+++ b/CDFModule/Public/func_Get-GitHubConfigApplication.ps1
@@ -52,7 +52,7 @@
 
     $sourcePath = "$SourceDir/$($CdfConfig.Platform.Config.platformId)/$($CdfConfig.Platform.Config.platformInstanceId)"
     $platformKey = "$($CdfConfig.Platform.Config.platformId)$($CdfConfig.Platform.Config.platformInstanceId)"
-    $applicationKey = "$($CdfConfig.Application.Config.templateName)$($CdfConfig.Application.Config.applicationInstanceId)"
+    $applicationKey = "$($CdfConfig.Application.Config.applicationId ?? $CdfConfig.Application.Config.templateName)$($CdfConfig.Application.Config.applicationInstanceId)"
     $platformEnvKey = "$platformKey$($CdfConfig.Platform.Env.nameId)"
     $applicationEnvKey = "$applicationKey$($CdfConfig.Application.Env.nameId)"
     $regionCode = $CdfConfig.Application.Config.regionCode

--- a/CDFModule/Public/func_Get-GitHubConfigDomain.ps1
+++ b/CDFModule/Public/func_Get-GitHubConfigDomain.ps1
@@ -53,7 +53,7 @@
 
     $sourcePath = "$SourceDir/$($CdfConfig.Platform.Config.platformId)/$($CdfConfig.Platform.Config.platformInstanceId)"
     $platformKey = "$($CdfConfig.Platform.Config.platformId)$($CdfConfig.Platform.Config.platformInstanceId)"
-    $applicationKey = "$($CdfConfig.Application.Config.templateName)$($CdfConfig.Application.Config.applicationInstanceId)"
+    $applicationKey = "$($CdfConfig.Application.Config.applicationId ?? $CdfConfig.Application.Config.templateName)$($CdfConfig.Application.Config.applicationInstanceId)"
     $platformEnvKey = "$platformKey$($CdfConfig.Platform.Env.nameId)"
     $applicationEnvKey = "$applicationKey$($CdfConfig.Application.Env.nameId)"
     $regionCode = $CdfConfig.Application.Config.regionCode

--- a/CDFModule/Public/func_Get-GitHubConfigService.ps1
+++ b/CDFModule/Public/func_Get-GitHubConfigService.ps1
@@ -55,7 +55,7 @@
 
     $sourcePath = "$SourceDir/$($CdfConfig.Platform.Config.platformId)/$($CdfConfig.Platform.Config.platformInstanceId)"
     $platformKey = "$($CdfConfig.Platform.Config.platformId)$($CdfConfig.Platform.Config.platformInstanceId)"
-    $applicationKey = "$($CdfConfig.Application.Config.templateName)$($CdfConfig.Application.Config.applicationInstanceId)"
+    $applicationKey = "$($CdfConfig.Application.Config.applicationId ?? $CdfConfig.Application.Config.templateName)$($CdfConfig.Application.Config.applicationInstanceId)"
     $platformEnvKey = "$platformKey$($CdfConfig.Platform.Env.nameId)"
     $applicationEnvKey = "$applicationKey$($CdfConfig.Application.Env.nameId)"
     $regionCode = $CdfConfig.Application.Config.regionCode

--- a/CDFModule/Public/func_Get-GitHubMatrix.ps1
+++ b/CDFModule/Public/func_Get-GitHubMatrix.ps1
@@ -142,7 +142,8 @@
 
                 }
                 $matrix += $env
-            } else {
+            }
+            else {
                 Write-Verbose "`tSkipping env is [$($platformEnv.isEnabled)]"
             }
 

--- a/CDFModule/Public/func_New-ConfigDomain.ps1
+++ b/CDFModule/Public/func_New-ConfigDomain.ps1
@@ -93,7 +93,7 @@
     }
 
     $platformKey = $CdfConfig.Platform.Config.platformId + $CdfConfig.Platform.Config.instanceId
-    $applicationKey = $CdfConfig.Application.Config.templateName + $CdfConfig.Application.Config.instanceId
+    $applicationKey = $CdfConfig.Application.Config.applicationId + $CdfConfig.Application.Config.instanceId
 
     Write-Information "Preparing application configuration for platform instance at [$sourcePath]"
 

--- a/CDFModule/Public/func_New-LetsEncryptCertificate.ps1
+++ b/CDFModule/Public/func_New-LetsEncryptCertificate.ps1
@@ -174,7 +174,7 @@
             $regionCode = $CdfConfig.Platform.Env.regionCode
             $platformKey = "$($CdfConfig.Platform.Config.platformId)$($CdfConfig.Platform.Config.instanceId)"
             $platformEnvKey = "$platformKey$($CdfConfig.Platform.Env.nameId)"
-            $applicationKey = "$($CdfConfig.Application.Config.templateName)$($CdfConfig.Application.Config.instanceId)"
+            $applicationKey = "$($CdfConfig.Application.Config.applicationId ?? $CdfConfig.Application.Config.templateName)$($CdfConfig.Application.Config.instanceId)"
             $applicationEnvKey = "$applicationKey$($CdfConfig.Application.Env.nameId)"
 
             $keyVault = Get-AzKeyVault -VaultName $CdfConfig.Application.ResourceNames.keyVaultName

--- a/CDFModule/Public/func_Remove-TemplateApplication.ps1
+++ b/CDFModule/Public/func_Remove-TemplateApplication.ps1
@@ -57,7 +57,7 @@
         $regionCode = $CdfConfig.Platform.Env.regionCode
         $platformKey = "$($CdfConfig.Platform.Config.platformId)$($CdfConfig.Platform.Config.instanceId)"
         $platformEnvKey = "$platformKey$($CdfConfig.Platform.Env.nameId)"
-        $applicationKey = "$($CdfConfig.Application.Config.templateName)$($CdfConfig.Application.Config.instanceId)"
+        $applicationKey = "$($CdfConfig.Application.Config.applicationId ?? $CdfConfig.Application.Config.templateName)$($CdfConfig.Application.Config.instanceId)"
         $applicationEnvKey = "$applicationKey$($CdfConfig.Application.Env.nameId)"
         $templateInstance = "$platformKey-$applicationKey-$regionCode"
         $templateEnvInstance = "$platformEnvKey-$applicationEnvKey-$regionCode"

--- a/CDFModule/Public/func_Remove-TemplateDomain.ps1
+++ b/CDFModule/Public/func_Remove-TemplateDomain.ps1
@@ -61,7 +61,7 @@ Function Remove-TemplateDomain {
         $regionCode = $CdfConfig.Platform.Env.regionCode
         $platformKey = "$($CdfConfig.Platform.Config.platformId)$($CdfConfig.Platform.Config.instanceId)"
         $platformEnvKey = "$platformKey$($CdfConfig.Platform.Env.nameId)"
-        $applicationKey = "$($CdfConfig.Application.Config.templateName)$($CdfConfig.Application.Config.instanceId)"
+        $applicationKey = "$($CdfConfig.Application.Config.applicationId ?? $CdfConfig.Application.Config.templateName)$($CdfConfig.Application.Config.instanceId)"
         $applicationEnvKey = "$applicationKey$($CdfConfig.Application.Env.nameId)"
         $templateInstance = "$platformKey-$applicationKey-$($CdfConfig.Domain.Config.domainName)-$regionCode"
         $templateEnvInstance = "$platformEnvKey-$applicationEnvKey-$($CdfConfig.Domain.Config.domainName)-$regionCode"

--- a/CDFModule/Public/func_Remove-TemplateService.ps1
+++ b/CDFModule/Public/func_Remove-TemplateService.ps1
@@ -61,7 +61,7 @@ Function Remove-TemplateService {
         $regionCode = $CdfConfig.Platform.Env.regionCode
         $platformKey = "$($CdfConfig.Platform.Config.platformId)$($CdfConfig.Platform.Config.instanceId)"
         $platformEnvKey = "$platformKey$($CdfConfig.Platform.Env.nameId)"
-        $applicationKey = "$($CdfConfig.Application.Config.templateName)$($CdfConfig.Application.Config.instanceId)"
+        $applicationKey = "$($CdfConfig.Application.Config.applicationId ?? $CdfConfig.Application.Config.templateName)$($CdfConfig.Application.Config.instanceId)"
         $applicationEnvKey = "$applicationKey$($CdfConfig.Application.Env.nameId)"
         $templateInstance = "$platformKey-$applicationKey-$($CdfConfig.Domain.Config.domainName)-$($CdfConfig.Service.Config.serviceName)-$regionCode"
         $templateEnvInstance = "$platformEnvKey-$applicationEnvKey-$($CdfConfig.Domain.Config.domainName)-$($CdfConfig.Service.Config.serviceName)-$regionCode"


### PR DESCRIPTION
The framework has introduced applicationId parameter instead of application templateName as a way to name runtime instance in the same way platform uses platformId. In this pull request the remaining occurances of application templateName have applicationId added as primary means for naming an application instance - applicationKey.