### PR TITLE
Bugfix api overwrite secret

### DIFF
--- a/CDFModule/Public/func_Deploy-ApimKeyVaultServiceNamedValues.ps1
+++ b/CDFModule/Public/func_Deploy-ApimKeyVaultServiceNamedValues.ps1
@@ -82,14 +82,14 @@
             elseif ($NamedValue.value -eq $CurrentSecret) {
                 Write-Host ' - Existing, match, no change'
             }
+            elseif ($null -eq $NamedValue.value ) {
+                Write-Host ' - No value provided, continue'
+            }
             else {
-                Write-Host ' - Existing, diff, update'
                 $SecretValue = ConvertTo-SecureString $NamedValue.value -AsPlainText -Force
                 $SetSecret = Set-AzKeyVaultSecret -VaultName $CdfConfig.Application.ResourceNames.keyVaultName -Name $NamedValue.secretName -SecretValue $SecretValue
                 #TODO: Handle error response
             }
         }
-
     }
-
 }

--- a/CDFModule/Public/func_Deploy-Service.ps1
+++ b/CDFModule/Public/func_Deploy-Service.ps1
@@ -49,7 +49,9 @@
     )
 
     # Initiate Service Deployment CDF Config
-    $SvcCdfConfig = $CdfConfig.Clone()
+    if ($null -ne $CdfConfig) {
+        $SvcCdfConfig = $CdfConfig.Clone()
+    }
 
     # Use "cdf-config.json" if available, but if parameter is bound it overrides / takes precedence
     $cdfConfigFile = Join-Path -Path $ServiceSrcPath  -ChildPath 'cdf-config.json'


### PR DESCRIPTION
For api services using named values it is allowed to provide a constant value that is pushed to KeyVault and referenced from APIM Named Values. This is in line with the default policies say all Named Values should be in KeyVault.

There are additional deployment scenarios where an acutal secret i pushed to KeyVault and needs to be referenced as a API Service NamedValue. In this scenario no value is provided. 

This fix will allow API Service KeyVault secrets in application keyvault to be referenced without providing a clear text value in cdf-config.json and at the same time avoid overwriting existing secret values in KeyVault with blank values.
