### PR TITLE
Bug fix for service env vars override from app.settings.json

### DIFF
--- a/CDFModule/Public/func_Deploy-ServiceContainerApp.ps1
+++ b/CDFModule/Public/func_Deploy-ServiceContainerApp.ps1
@@ -79,7 +79,7 @@
     Copy-Item -Force -Recurse -Include $containerFiles -Path $InputPath/* -Destination $OutputPath
 
     ## Adjust these if template changes regarding placement of appService for the service
-    $containerAppRG = $CdfConfig.Service.ResourceNames.appServiceResourceGroup ?? $CdfConfig.Service.ResourceNames.serviceResourceGroup 
+    $containerAppRG = $CdfConfig.Service.ResourceNames.appServiceResourceGroup ?? $CdfConfig.Service.ResourceNames.serviceResourceGroup
     $containerAppName = $CdfConfig.Service.ResourceNames.appServiceName ?? $CdfConfig.Service.ResourceNames.serviceResourceName
 
     Write-Host "containerAppRG: $containerAppRG"

--- a/CDFModule/Public/func_Deploy-ServiceContainerAppService.ps1
+++ b/CDFModule/Public/func_Deploy-ServiceContainerAppService.ps1
@@ -2,7 +2,7 @@
     <#
         .SYNOPSIS
         Deploys a Container App Service implementation and condfiguration
-        
+
         .SYNOPSIS
         Deploys a Container service to an App Service implementation and configuration
 
@@ -67,7 +67,7 @@
     }
 
     ## Adjust these if template changes regarding placement of logicapp for the service
-    $appServiceRG = $CdfConfig.Service.ResourceNames.appServiceResourceGroup ?? $CdfConfig.Service.ResourceNames.serviceResourceGroup 
+    $appServiceRG = $CdfConfig.Service.ResourceNames.appServiceResourceGroup ?? $CdfConfig.Service.ResourceNames.serviceResourceGroup
     $appServiceName = $CdfConfig.Service.ResourceNames.appServiceName ?? $CdfConfig.Service.ResourceNames.serviceResourceName
 
 
@@ -105,15 +105,13 @@
 
     $appSettings = $app.SiteConfig.AppSettings
 
-    # Preparing hashtable with existing app config
+    # Preparing hashtable with exsting config
     $updateSettings = ConvertFrom-Json -InputObject "{}" -AsHashtable
     foreach ($setting in $appSettings) {
         $updateSettings[$setting.Name] = $setting.Value
     }
 
-    # Update with CDF Standard settings
-    $updateSettings = $CdfConfig `
-    | Get-ServiceConfigSettings `
+    $updateSettings = $CdfConfig | Get-ServiceConfigSettings `
         -UpdateSettings $updateSettings `
         -InputPath $InputPath `
         -ErrorAction:Stop

--- a/CDFModule/Public/func_Deploy-ServiceFunctionApp.ps1
+++ b/CDFModule/Public/func_Deploy-ServiceFunctionApp.ps1
@@ -89,8 +89,8 @@
     Copy-Item -Force -Recurse -Path $InputPath/* -Destination $OutputPath
 
     ## Adjust these if template changes regarding placement of appService runtime for the service
-    $appServiceRG = $CdfConfig.Service.ResourceNames.appServiceResourceGroup ?? $CdfConfig.Service.ResourceNames.serviceResourceGroup
-    $appServiceName = $CdfConfig.Service.ResourceNames.appServiceName ?? $CdfConfig.Service.ResourceNames.serviceResourceName
+    $appServiceRG = $CdfConfig.Service.ResourceNames.appServiceResourceGroup ?? $CdfConfig.Service.ResourceNames.functionAppResourceGroup ?? $CdfConfig.Service.ResourceNames.serviceResourceGroup
+    $appServiceName = $CdfConfig.Service.ResourceNames.appServiceName ?? $CdfConfig.Service.ResourceNames.functionAppName ?? $CdfConfig.Service.ResourceNames.serviceResourceName
 
     Write-Host "AppServiceRG: $appServiceRG"
     Write-Host "AppServiceName: $appServiceName"
@@ -125,12 +125,7 @@
     $updateSettings["SVC_API_BASEURL"] = "https://$($app.HostNames[0])"
     $BaseUrls = @()
     foreach ($hostName in $app.HostNames) { $BaseUrls += "https://$hostName" }
-    $updateSettings["SVC_API_BASEURLS"] = $BaseUrls | Join-String -Separator ','
-
-    # Run from package. Not to be used with .net functions app
-    #$updateSettings["WEBSITE_RUN_FROM_PACKAGE"] = "0"
-    #$updateSettings["SCM_DO_BUILD_DURING_DEPLOYMENT"] = "true"
-    #$updateSettings["ENABLE_ORYX_BUILD"] = "true"
+    $updateSettings["SVC_API_BASEURLS"] = [string] ($BaseUrls | Join-String -Separator ',')
 
     #-------------------------------------------------------------
     # Update the app settings
@@ -155,7 +150,15 @@
     # '*/node_modules/azure-functions-core-tools/*'
     # '*/node_modules/typescript/*'
     [string[]]$exclude = @(
-        'app.settings.*'
+        '.vscode',
+        '.gitignore',
+        '.funcignore',
+        '.dockerignore',
+        'Dockerfile',
+        'app.settings.*',
+        'local.settings.json',
+        'cdf-config.json',
+        'cdf-secrets.json'
     )
     $OutputPath = Resolve-Path $OutputPath
     New-Zip `

--- a/CDFModule/Public/func_Deploy-ServiceFunctionApp.ps1
+++ b/CDFModule/Public/func_Deploy-ServiceFunctionApp.ps1
@@ -66,7 +66,7 @@
         Write-Error "Service mismatch - does not match a FunctionApp implementation."
         return
     }
-    
+
     Write-Host "Preparing Function App Service implementation deployment."
 
     $azCtx = Get-AzureContext -SubscriptionId $CdfConfig.Platform.Env.subscriptionId
@@ -89,7 +89,7 @@
     Copy-Item -Force -Recurse -Path $InputPath/* -Destination $OutputPath
 
     ## Adjust these if template changes regarding placement of appService runtime for the service
-    $appServiceRG = $CdfConfig.Service.ResourceNames.appServiceResourceGroup ?? $CdfConfig.Service.ResourceNames.serviceResourceGroup 
+    $appServiceRG = $CdfConfig.Service.ResourceNames.appServiceResourceGroup ?? $CdfConfig.Service.ResourceNames.serviceResourceGroup
     $appServiceName = $CdfConfig.Service.ResourceNames.appServiceName ?? $CdfConfig.Service.ResourceNames.serviceResourceName
 
     Write-Host "AppServiceRG: $appServiceRG"
@@ -109,13 +109,18 @@
 
     $appSettings = $app.SiteConfig.AppSettings
 
+
     # Preparing hashtable with exsting config
     $updateSettings = ConvertFrom-Json -InputObject "{}" -AsHashtable
     foreach ($setting in $appSettings) {
         $updateSettings[$setting.Name] = $setting.Value
     }
 
-    Get-ServiceConfigSettings -CdfConfig $CdfConfig -UpdateSettings $updateSettings -InputPath $InputPath -Deployed
+    $updateSettings = $CdfConfig | Get-ServiceConfigSettings `
+        -UpdateSettings $updateSettings `
+        -InputPath $InputPath `
+        -ErrorAction:Stop
+
     # Configure service API URLs
     $updateSettings["SVC_API_BASEURL"] = "https://$($app.HostNames[0])"
     $BaseUrls = @()
@@ -127,43 +132,11 @@
     #$updateSettings["SCM_DO_BUILD_DURING_DEPLOYMENT"] = "true"
     #$updateSettings["ENABLE_ORYX_BUILD"] = "true"
 
-
-    # Add default app settings if exists - override any generated app settings
-    if (Test-Path "$OutputPath/app.settings.json") {
-        Write-Host "Loading settings from app.settings.json"
-        $defaultSettings = Get-Content -Raw "$OutputPath/app.settings.json" | ConvertFrom-Json -AsHashtable
-        foreach ($key in $defaultSettings.Keys) {
-            Write-Verbose "Adding parameter appsetting for [$key] value [$($defaultSettings[$key])]"
-            $updateSettings[$key] = $defaultSettings[$key]
-        }
-    }
     #-------------------------------------------------------------
     # Update the app settings
     #-------------------------------------------------------------
     $updateSettings | ConvertTo-Json -Depth 10 | Set-Content -Path "$OutputPath/app.settings.gen.json"
     Remove-Item -Path "$OutputPath/local.settings.json" -ErrorAction SilentlyContinue
-
-    #-------------------------------------------------------------
-    # Preparing the app settings
-    #-------------------------------------------------------------
-
-    $updateSettings | ConvertTo-Json -Depth 10 | Set-Content -Path "$OutputPath/app.settings.raw.json"
-
-    # Substitute Tokens in the app.settings file
-    $tokenValues = $CdfConfig | Get-TokenValues
-    Update-ConfigFileTokens `
-        -InputFile "$OutputPath/app.settings.raw.json" `
-        -OutputFile "$OutputPath/app.settings.json" `
-        -Tokens $tokenValues `
-        -StartTokenPattern '{{' `
-        -EndTokenPattern '}}' `
-        -NoWarning `
-        -WarningAction:SilentlyContinue
-
-    Remove-Item -Path "$OutputPath/local.settings.json" -ErrorAction SilentlyContinue
-
-    # Read generated app.settings file with token substitutions
-    $updateSettings = Get-Content -Path "$OutputPath/app.settings.json" | ConvertFrom-Json -Depth 10 -AsHashtable
 
     Set-AzWebApp `
         -Name $appServiceName `
@@ -175,7 +148,6 @@
     # Deploy function app implementation
     #--------------------------------------
     Write-Host "Deploying functions."
-
 
     # '*.ts'
     # '*/tsconfig.json'

--- a/CDFModule/Public/func_Deploy-ServiceLogicAppStd.ps1
+++ b/CDFModule/Public/func_Deploy-ServiceLogicAppStd.ps1
@@ -65,9 +65,9 @@
         Write-Error "Service mismatch - does not match a Logic App Standard implementation."
         return
     }
-    
+
     ## Adjust these if template changes regarding placement of logicapp for the service
-    $logicAppRG = $CdfConfig.Service.ResourceNames.logicAppResourceGroup ?? $CdfConfig.Service.ResourceNames.serviceResourceGroup 
+    $logicAppRG = $CdfConfig.Service.ResourceNames.logicAppResourceGroup ?? $CdfConfig.Service.ResourceNames.serviceResourceGroup
     $logicAppName = $CdfConfig.Service.ResourceNames.logicAppName ?? $CdfConfig.Service.ResourceNames.serviceResourceName
 
     Write-Verbose "logicAppRG: $logicAppRG"
@@ -140,15 +140,14 @@
 
     # Preparing hashtable with exsting config
     $updateSettings = ConvertFrom-Json -InputObject "{}" -AsHashtable
-    $updateSettings = $CdfConfig `
-    | Get-ServiceConfigSettings `
-        -UpdateSettings $updateSettings `
-        -InputPath $InputPath `
-        -ErrorAction:Stop
-
     foreach ($setting in $appSettings) {
         $updateSettings[$setting.Name] = $setting.Value
     }
+
+    $updateSettings = $CdfConfig | Get-ServiceConfigSettings `
+        -UpdateSettings $updateSettings `
+        -InputPath $InputPath `
+        -ErrorAction:Stop
 
     Set-LogicAppParameters `
         -CdfConfig $CdfConfig `
@@ -272,15 +271,15 @@
                 -Name $logicAppName `
                 -ResourceGroupName $logicAppRG `
                 -AppSettings $updateSettings `
-                -WarningAction:SilentlyContinue 
+                -WarningAction:SilentlyContinue
             #| Out-Null
-            
+
             Publish-AzWebApp -Force `
                 -DefaultProfile $azCtx `
                 -Name $logicAppName `
                 -ResourceGroupName $logicAppRG `
                 -ArchivePath "$OutputPath/deployment-package-$($CdfConfig.Service.Config.serviceName).zip" `
-                -WarningAction:SilentlyContinue 
+                -WarningAction:SilentlyContinue
             #| Out-Null
             break
         }

--- a/CDFModule/Public/func_Get-ServiceConfigSettings.ps1
+++ b/CDFModule/Public/func_Get-ServiceConfigSettings.ps1
@@ -197,11 +197,10 @@ Function Get-ServiceConfigSettings {
     # Add default/override app settings if exists - override any generated app settings
     if (Test-Path "$OutputPath/app.settings.json") {
         Write-Host "Loading settings from app.settings.json"
-        $defaultSettings = (`
-                Get-Content "$OutputPath/app.settings.json" `
-            | ConvertFrom-Json -AsHashtable `
-            | Update-ConfigToken -NoWarning -Tokens ($CdfConfig | Get-TokenValues) `
-        )
+        $defaultSettings = Get-Content -Path "$OutputPath/app.settings.json" -Raw `
+        | Update-ConfigToken -NoWarning -Tokens ($CdfConfig | Get-TokenValues) `
+        | ConvertFrom-Json -AsHashtable
+
         foreach ($key in $defaultSettings.Keys) {
             Write-Verbose "Adding/overriding parameter appsetting for [$key] value [$($defaultSettings[$key])]"
             $UpdateSettings[$key] = [string] $defaultSettings[$key]


### PR DESCRIPTION
For CDF v1.2 a refactoring was made for service environment variable configuration. Part of this refactoring a bug was introduced which effectively disabled any service environment variable overrides using `app.setting.json` file.

This PR corrects the implementation and align the environment settings for all AppService-based deployments. For functions it also removes redundant Token Substitution which already takes place in the Get-ServiceConfigSettings command.