### PR TITLE
Fetch domain config from file

### DIFF
--- a/CDFModule/Public/func_Get-Config.ps1
+++ b/CDFModule/Public/func_Get-Config.ps1
@@ -125,7 +125,7 @@
       -ErrorAction Stop
   }
 
-  if ($DomainName -and $config.Application.IsDeployed) {
+  if ($DomainName) {
 
 
     if ($Deployed) {


### PR DESCRIPTION
The Get-CdfConfig command did not allow for the domain config to be fetched from file, only deployed configs. It is now possible to fetch CDF Config from file (IsDeployed = $false) for all infrastructure scopes - Platform. Application and Domain.