### PR TITLE
fix: error when no domain config

### DIFF
--- a/CDFModule/Public/func_Show-Config.ps1
+++ b/CDFModule/Public/func_Show-Config.ps1
@@ -208,7 +208,7 @@
       # Continue Domain configuration
     }
 
-    if ($Deployed) {
+    if ($Deployed -and $config.Domain -and $config.Domain.Env -and $config.Domain.Env.Count -gt 0) {
       $config = Get-ConfigDomain `
         -CdfConfig $config `
         -DomainName $DomainName `


### PR DESCRIPTION
For infrastructure configurations with no domain configuration an error is shown for the "Show-CdfConfig" command. This has been fixed.