### PR TITLE
Improved service configuration

### DIFF
--- a/CDFModule/Public/func_Deploy-Service.ps1
+++ b/CDFModule/Public/func_Deploy-Service.ps1
@@ -224,7 +224,8 @@
         }
     }
 
-    if ($ServiceTemplate -eq 'logicapp-standard') {
+    # TODO: Refactor in a registration pattern for supported service template commands
+    if ($ServiceTemplate.StartsWith('logicapp-')) {
         Deploy-ServiceLogicAppStd `
             -CdfConfig $SvcCdfConfig `
             -InputPath $ServiceSrcPath `
@@ -232,7 +233,7 @@
             -TemplateDir $CdfSharedPath/modules `
             -ErrorAction Stop
     }
-    elseif ($ServiceTemplate -eq 'functionapp') {
+    elseif ($ServiceTemplate.StartsWith('functionapp-')) {
         Deploy-ServiceFunctionApp `
             -CdfConfig $SvcCdfConfig `
             -InputPath $ServiceSrcPath `

--- a/CDFModule/Public/func_Deploy-Service.ps1
+++ b/CDFModule/Public/func_Deploy-Service.ps1
@@ -383,7 +383,7 @@
         $SvcCdfConfig.Service.IsDeployed = $true
     }
     else {
-        Write-Error "Unable to determine service implementation. Supported ServiceTemplate keywords include 'api-*', 'logicapp-standard', 'container-*'."
+        Write-Error "Unable to determine service implementation [$ServiceTemplate]. Supported ServiceTemplate prefixes are 'api-', 'logicapp-', 'container-' and 'functionapp-'."
     }
     return $SvcCdfConfig
 }

--- a/CDFModule/Public/func_Deploy-TemplateService.ps1
+++ b/CDFModule/Public/func_Deploy-TemplateService.ps1
@@ -108,12 +108,23 @@
     $templateParams.domainAccessControl = $CdfConfig.Domain.AccessControl
     $templateParams.domainResourceNames = $CdfConfig.Domain.ResourceNames
 
+    $templateParams.serviceConfig = $CdfConfig.Service -and $CdfConfig.Service.Config ? $CdfConfig.Service.Config ?? @{} : @{}
+    $templateParams.serviceConfig.serviceName = $ServiceName
+    $templateParams.serviceConfig.serviceType = $ServiceType
+    $templateParams.serviceConfig.serviceGroup = $ServiceGroup
+    $templateParams.serviceConfig.serviceTemplate = $ServiceTemplate
+
+    $templateParams.serviceFeatures = $CdfConfig.Service -and $CdfConfig.Service.serviceFeatures ? $CdfConfig.Service.serviceFeatures ?? @{} : @{}
+    $templateParams.serviceNetworkConfig = $CdfConfig.Service -and $CdfConfig.Service.serviceNetworkConfig ? $CdfConfig.Service.serviceNetworkConfig ?? @{} : @{}
+    $templateParams.serviceAccessControl = $CdfConfig.Service -and $CdfConfig.Service.serviceAccessControl ? $CdfConfig.Service.serviceAccessControl ?? @{} : @{}
+
     $templateParams.serviceTags = @{} # TODO: Implement default configurable service tags or inherit domain default tags??
     $templateParams.serviceTags.BuildCommit = $env:GITHUB_SHA ?? $env:BUILD_SOURCEVERSION ?? $(git -C $TemplateDir rev-parse --short HEAD)
     $templateParams.serviceTags.BuildRun = $env:GITHUB_RUN_ID ?? $env:BUILD_BUILDNUMBER ?? "local"
     $templateParams.serviceTags.BuildBranch = $env:GITHUB_REF_NAME ?? $env:BUILD_SOURCEBRANCH ?? $(git -C $TemplateDir branch --show-current)
     $templateParams.serviceTags.BuildRepo = $env:GITHUB_REPOSITORY ?? $env:BUILD_REPOSITORY_NAME ?? $(Split-Path -Leaf (git -C $TemplateDir remote get-url origin))
 
+    # TODO: Remove these - deprecated. Kept for now not to break compatbility with old templates.
     $templateParams.serviceName = $ServiceName
     $templateParams.serviceType = $ServiceType
     $templateParams.serviceGroup = $ServiceGroup


### PR DESCRIPTION
# Improved CDF service configuration

This PR includes a set of changes to improve CDF service configuration and deployment

* Enhancement of _Deploy-CdfTemplateService_, and alignment of Service template deployment parameters with Platform, Application and Domain , adding `serviceConfig`, `serviceFeature`, `serviceNetworkConfig` and `serviceAccessControl` to allow for more configurability of the service templates. This is a breaking change for CDF V1.1 templates and required adding these two bicep parameters as empty default objects to prepare for use of CDF V1.2 and onwards.
* Part of adding `serviceConfig` parameter the `serviceName`, `serviceGroup`, `serviceType` and `serviceTemplate` are moved into `serviceConfig` parameter object. They remain for backwards compatibility but are considered deprecated from CDF V1.2.
* Enhancement for _Deploy-CdfContainerAppService_ where image name and tag can be provided in a more convenient way for scripting/automation using environment variabes `CDF_IMAGE_NAME` and `CDF_IMAGE_TAG`.
* Enhancement for _Deploy-CdfContainerAppService_ where it is possible to control the number of replicas for a container using `serviceConfig` object properties `replicasMin`and `replicasMax`
* The _Deploy-CdfService_ command has a more generalized matching of service templates
* A bugfix for _Deploy-CdfContainerAppService_ where deployment would fail on missing KeyVault secret

## Service bicep template changes v1.1 to v1.2

The current required bicep template parameters for a CDF v1.1 service 

```bicep
# CDF v1.1 only uses these input parameters
param serviceTags object = {}
param serviceName string
param serviceGroup string
param serviceType string
param serviceTemplate string
```

New CDF v1.2 bicep template parameters which are backwards compatible with CDF v1.1 from a CDFModule command perspective.

```bicep
# CDF v1.2 requires the following two parameters to be added to templates
param serviceTags object = {}
param serviceConfig object = {}
param serviceFeature object = {}
param serviceNetworkConfig object = {}
param serviceAccessControl object = {}

# These are deprecated from CDF v1.2 and should be updated to default to their serviceConfig property counterparts
param serviceName string = serviceConfig.serviceName
param serviceGroup string = serviceConfig.serviceGroup
param serviceType string = serviceConfig.serviceType
param serviceTemplate string = serviceConfig.serviceTemplate
```
