### PR TITLE
Functionality for enabling Postgres Server at Platform and Domain Level

### DIFF
--- a/CDFModule/Private/func_GeneratePassword.ps1
+++ b/CDFModule/Private/func_GeneratePassword.ps1
@@ -1,0 +1,46 @@
+Function GeneratePassword {
+    [CmdletBinding()]
+    Param(
+        [ValidateRange(8,16)]
+        [int] $Length = 12,
+        [int] $Upper = 1,
+        [int] $Lower = 1,
+        [int] $Numeric = 1,
+        [int] $Special = 1
+    )
+
+    if($Upper + $Lower + $Numeric + $Special -gt $Length) {
+        throw "Total of Upper/Lower/Numeric/Special char must be less than or equal to length."
+    }
+    $uCharSet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+    $lCharSet = "abcdefghijklmnopqrstuvwxyz"
+    $nCharSet = "0123456789"
+    $sCharSet = "*-+,!=._"
+    $charSet = ""
+    if($Upper -gt 0) { $charSet += $uCharSet }
+    if($Lower -gt 0) { $charSet += $lCharSet }
+    if($Numeric -gt 0) { $charSet += $nCharSet }
+    if($Special -gt 0) { $charSet += $sCharSet }
+    $charSet = $charSet.ToCharArray()
+    $valid = $false
+
+    while($valid -eq $false)
+    {
+    $rng = New-Object System.Security.Cryptography.RNGCryptoServiceProvider
+    $bytes = New-Object byte[]($Length)
+    $rng.GetBytes($bytes)
+    $result = New-Object char[]($Length)
+    for ($i = 0 ; $i -lt $Length ; $i++) {
+        $result[$i] = $charSet[$bytes[$i] % $charSet.Length]
+    }
+    $password = (-join $result)
+    $valid = $true
+    if($Upper   -gt ($password.ToCharArray() | Where-Object {$_ -cin $uCharSet.ToCharArray() }).Count) { $valid = $false }
+    if($Lower   -gt ($password.ToCharArray() | Where-Object {$_ -cin $lCharSet.ToCharArray() }).Count) { $valid = $false }
+    if($Numeric -gt ($password.ToCharArray() | Where-Object {$_ -cin $nCharSet.ToCharArray() }).Count) { $valid = $false }
+    if($Special -gt ($password.ToCharArray() | Where-Object {$_ -cin $sCharSet.ToCharArray() }).Count) { $valid = $false }
+    if($valid) {
+        return ConvertTo-SecureString $password -AsPlainText -Force
+    }
+}
+}

--- a/CDFModule/Private/func_Get-IP.ps1
+++ b/CDFModule/Private/func_Get-IP.ps1
@@ -1,0 +1,3 @@
+Function Get-IP {
+    return Invoke-RestMethod -Uri "https://api.ipify.org/"
+}

--- a/CDFModule/Public/func_Deploy-PostgresConfig.ps1
+++ b/CDFModule/Public/func_Deploy-PostgresConfig.ps1
@@ -64,6 +64,8 @@
                 $DomainDbPassword = GeneratePassword
                 $DatabaseName = $DomainName
                 $DatabaseUser = $DomainName
+                $DatabaseUserSecretName = "Domain-$DomainName-Postgres-UserName"
+                $DatabasePasswordSecretName = "Domain-$DomainName-Postgres-Password"
                 Write-Host "Preparing Postgres database, user and permissions."
                 $PlainDomainDbPassword = (New-Object System.Net.NetworkCredential("", $DomainDbPassword)).Password
                 $env:PGPASSWORD = $AdminPassword
@@ -95,8 +97,6 @@
                                     if ($LASTEXITCODE -ne 0) {
                                         throw $output
                                     }
-                                    $DatabaseUserSecretName = "Domain-$DomainName-Postgres-UserName"
-                                    $DatabasePasswordSecretName = "Domain-$DomainName-Postgres-Password"
                                     $null = Set-AzKeyVaultSecret `
                                         -VaultName $CdfConfig.Platform.ResourceNames.keyVaultName `
                                         -Name $DatabasePasswordSecretName `
@@ -106,9 +106,6 @@
                                         -VaultName $CdfConfig.Platform.ResourceNames.keyVaultName `
                                         -Name  $DatabaseUserSecretName `
                                         -SecretValue $DatabaseUserName
-                                    $OutputDetails.Add("Postgres-UserSecretName", $DatabaseUserSecretName)
-                                    $OutputDetails.Add("Postgres-PasswordSecretName", $DatabasePasswordSecretName)
-                                    $OutputDetails.Add("Postgres-Database", $DatabaseName)
                                 }
                                 else {
                                     Write-Host 'Domain user already exists.'
@@ -117,6 +114,9 @@
                         }
                     }
                 }
+                $OutputDetails.Add("Postgres-UserSecretName", $DatabaseUserSecretName)
+                $OutputDetails.Add("Postgres-PasswordSecretName", $DatabasePasswordSecretName)
+                $OutputDetails.Add("Postgres-Database", $DatabaseName)
             }
             return ,$OutputDetails;
         }

--- a/CDFModule/Public/func_Deploy-PostgresConfig.ps1
+++ b/CDFModule/Public/func_Deploy-PostgresConfig.ps1
@@ -1,0 +1,127 @@
+﻿Function Deploy-PostgresConfig {
+    <#
+    .SYNOPSIS
+    Deploy service bus queues, topics and subscriptions
+
+    .DESCRIPTION
+    The cmdlet makes token substitution for the Platform config environment.
+    Then deploys the service bus queues, topics and subscriptions for the service bus resource.
+
+    .PARAMETER CdfConfig
+    The CDFConfig object that holds the current scope configurations (Platform, Application and Domain)
+
+    .PARAMETER InputPath
+    The deployment package path, where servicebus.config.json is located.
+    Optional, defaults to "./build"
+
+    .PARAMETER OutputPath
+    Output path for the environment specific config file servicebus.config.<env nameId>.json
+    Optional, defaults to "./build"
+
+    .PARAMETER TemplateDir
+    Path to the bicep template folder where main.bicep is found. Defaults to ".".
+
+    .INPUTS
+    None. You cannot pipe objects.
+
+    .OUTPUTS
+    None.
+
+    .EXAMPLE
+    Deploy-CdfPostgresConfig `
+        -CdfConfig $config `
+        -Scope "Platform"
+
+    .LINK
+    Deploy-CdfTemplateDomain
+    #>
+
+    [CmdletBinding()]
+    Param(
+        [Parameter(ValueFromPipeline = $true, Mandatory = $false)]
+        [Object]$CdfConfig,
+        [Parameter(Mandatory = $true)]
+        [string] $Scope
+    )
+
+    Begin {}
+    Process {
+        try {
+            if ($CdfConfig.Domain.Features.usePostgres) {
+                $ServerName = $CdfConfig.Platform.ResourceNames.postgresFQDN
+                $DefaultDatabase = 'postgres'
+                $Port = 5432
+                $DomainName = $CdfConfig.Domain.Config.domainName
+                $AdminUserName = Get-AzKeyVaultSecret `
+                    -VaultName $CdfConfig.Platform.ResourceNames.keyVaultName `
+                    -Name $CdfConfig.Platform.Config.platformPostgres.adminUserSecretName `
+                    -AsPlainText
+                $AdminPassword = Get-AzKeyVaultSecret `
+                    -VaultName $CdfConfig.Platform.ResourceNames.keyVaultName `
+                    -Name $CdfConfig.Platform.Config.platformPostgres.adminPasswordSecretName `
+                    -AsPlainText
+                #$AdminPassword = ConvertTo-SecureString -String $AdminPassword -AsPlainText -Force
+                $DomainDbPassword = GeneratePassword
+                
+                Write-Host "Preparing Postgres database, user and permissions."
+                $PlainDomainDbPassword = (New-Object System.Net.NetworkCredential("", $DomainDbPassword)).Password
+                #$plainAdminPassword = (New-Object System.Net.NetworkCredential("", $AdminPassword)).Password
+                # Environment variable PGPASSWORD is needed for Login
+                $env:PGPASSWORD = $AdminPassword
+                #Command to check if database exists
+                $checkDbQuery = "SELECT EXISTS(SELECT 1 FROM pg_database WHERE datname = '$DomainName');"
+                $checkRoleQuery = "SELECT EXISTS(SELECT 1 FROM pg_roles WHERE rolname = '$DomainName');"
+                $databaseExists = & psql -h $ServerName -U $AdminUserName -d $DefaultDatabase -p $Port -c $checkDbQuery
+                if ($LASTEXITCODE -ne 0) {
+                    throw $databaseExists
+                }
+                else {
+                    if ($databaseExists -match "f") {
+                        $output = & psql -h $ServerName -U $AdminUserName -d $DefaultDatabase -p $Port -c "CREATE DATABASE $DomainName;"
+                        if ($LASTEXITCODE -ne 0) {
+                            throw $output
+                        }
+                        else {
+                            $roleExists = & psql -h $ServerName -U $AdminUserName -d $DefaultDatabase -p $Port -c $checkRoleQuery
+                            if ($LASTEXITCODE -ne 0) {
+                                throw $roleExists
+                            }
+                            else {
+                                if ($roleExists -match "f") {
+                                    $output = & psql -h $ServerName -U $AdminUserName -d $DefaultDatabase -p $Port -c "CREATE USER $DomainName WITH PASSWORD '$plainDomainDbPassword';"
+                                    if ($LASTEXITCODE -ne 0) {
+                                        throw $output
+                                    }
+                                    $output = & psql -h $ServerName -U $AdminUserName -d $DefaultDatabase -p $Port -c "GRANT ALL PRIVILEGES ON DATABASE $DomainName TO $DomainName;"
+                                    if ($LASTEXITCODE -ne 0) {
+                                        throw $output
+                                    }
+                                    Set-AzKeyVaultSecret `
+                                        -VaultName $CdfConfig.Domain.ResourceNames.keyVaultName `
+                                        -Name "Domain-Postgres-Password" `
+                                        -SecretValue $DomainDbPassword
+                                    $DatabaseUserName = ConvertTo-SecureString -String $DomainName -AsPlainText -Force
+                                    Set-AzKeyVaultSecret `
+                                        -VaultName $CdfConfig.Domain.ResourceNames.keyVaultName `
+                                        -Name "Domain-Postgres-UserName" `
+                                        -SecretValue $DatabaseUserName
+                                }
+                                else {
+                                    Write-Host 'Domain user already exists.'
+                                    return $false
+                                }
+                            }
+                        }
+                    }
+                }
+                return $true;
+            }
+        }
+        catch {
+            Write-Host $_;
+            throw $_;
+        }
+    }
+    End {
+    }
+}

--- a/CDFModule/Public/func_Deploy-PostgresConfig.ps1
+++ b/CDFModule/Public/func_Deploy-PostgresConfig.ps1
@@ -1,25 +1,16 @@
 ﻿Function Deploy-PostgresConfig {
     <#
     .SYNOPSIS
-    Deploy service bus queues, topics and subscriptions
+    Deploy postgres database, user and permission for a domain and a schema under domain database.
 
     .DESCRIPTION
-    The cmdlet makes token substitution for the Platform config environment.
-    Then deploys the service bus queues, topics and subscriptions for the service bus resource.
+    The cmdlet Deploy postgres database, user and permission for a domain and a schema under domain database.
 
     .PARAMETER CdfConfig
     The CDFConfig object that holds the current scope configurations (Platform, Application and Domain)
 
-    .PARAMETER InputPath
-    The deployment package path, where servicebus.config.json is located.
-    Optional, defaults to "./build"
-
-    .PARAMETER OutputPath
-    Output path for the environment specific config file servicebus.config.<env nameId>.json
-    Optional, defaults to "./build"
-
-    .PARAMETER TemplateDir
-    Path to the bicep template folder where main.bicep is found. Defaults to ".".
+    .PARAMETER Scope
+    Target scope : Domain or Service
 
     .INPUTS
     None. You cannot pipe objects.
@@ -30,10 +21,15 @@
     .EXAMPLE
     Deploy-CdfPostgresConfig `
         -CdfConfig $config `
-        -Scope "Platform"
+        -Scope "Domain"
+
+    Deploy-CdfPostgresConfig `
+        -CdfConfig $config `
+        -Scope "Service"
 
     .LINK
     Deploy-CdfTemplateDomain
+    Deploy-CdfService
     #>
 
     [CmdletBinding()]
@@ -62,7 +58,7 @@
                     $RuleName = "BuildAgentIP-$Scope-$DomainName-Deployment"
                 }
                 else {
-                    $ServiceName = 'test'#$CdfConfig.Service.Config.serviceName
+                    $ServiceName = $CdfConfig.Service.Config.serviceName
                     $RuleName = "BuildAgentIP-$Scope-$DomainName-Deployment"
                 }
 

--- a/CDFModule/Public/func_Deploy-TemplateDomain.ps1
+++ b/CDFModule/Public/func_Deploy-TemplateDomain.ps1
@@ -77,7 +77,7 @@ Function Deploy-TemplateDomain {
         $platformEnvKey = "$($CdfConfig.Platform.Config.platformId)$($CdfConfig.Platform.Config.instanceId)$($CdfConfig.Platform.Env.nameId)"
         $applicationEnvKey = "$($CdfConfig.Application.Config.applicationId ?? $CdfConfig.Application.Config.templateName)$($CdfConfig.Application.Config.instanceId)$($CdfConfig.Application.Env.nameId)"
         $deploymentName = "domain-$platformEnvKey-$applicationEnvKey-$($CdfConfig.Domain.Config.domainName)-$regionCode"
-
+        $postgresConfigOutput = $CdfConfig | Deploy-PostgresConfig
         # Setup platform parameters from envrionment and params file
         $templateParams = [ordered] @{}
 
@@ -95,6 +95,11 @@ Function Deploy-TemplateDomain {
 
         $templateParams.domainConfig = $CdfConfig.Domain.Config
         $templateParams.domainFeatures = $CdfConfig.Domain.Features
+        if($postgresConfigOutput.Count -ne 0){
+            $templateParams.domainConfig.Add("postgresDatabaseName",$postgresConfigOutput["Postgres-Database"])
+            $templateParams.domainConfig.Add("postgresUserSecretName",$postgresConfigOutput["Postgres-UserSecretName"])
+            $templateParams.domainConfig.Add("postgresPasswordSecretName",$postgresConfigOutput["Postgres-PasswordSecretName"])
+        }
         $templateParams.domainNetworkConfig = $CdfConfig.Domain.NetworkConfig ?? @{}
         $templateParams.domainAccessControl = $CdfConfig.Domain.AccessControl ?? @{}
 

--- a/CDFModule/Public/func_Deploy-TemplateDomain.ps1
+++ b/CDFModule/Public/func_Deploy-TemplateDomain.ps1
@@ -95,10 +95,17 @@ Function Deploy-TemplateDomain {
 
         $templateParams.domainConfig = $CdfConfig.Domain.Config
         $templateParams.domainFeatures = $CdfConfig.Domain.Features
-        if($postgresConfigOutput.Count -ne 0){
-            $templateParams.domainConfig.Add("postgresDatabaseName",$postgresConfigOutput["Postgres-Database"])
-            $templateParams.domainConfig.Add("postgresUserSecretName",$postgresConfigOutput["Postgres-UserSecretName"])
-            $templateParams.domainConfig.Add("postgresPasswordSecretName",$postgresConfigOutput["Postgres-PasswordSecretName"])
+        if ($postgresConfigOutput.Count -ne 0) {
+            if ($templateParams.domainConfig.ContainsKey("postgresDatabaseName")) {
+                $templateParams.domainConfig["postgresDatabaseName"] = $postgresConfigOutput["Postgres-Database"]
+                $templateParams.domainConfig["postgresUserSecretName"] = $postgresConfigOutput["Postgres-UserSecretName"]
+                $templateParams.domainConfig["postgresPasswordSecretName"] = $postgresConfigOutput["Postgres-PasswordSecretName"]
+            }
+            else {
+                $templateParams.domainConfig.Add("postgresDatabaseName", $postgresConfigOutput["Postgres-Database"])
+                $templateParams.domainConfig.Add("postgresUserSecretName", $postgresConfigOutput["Postgres-UserSecretName"])
+                $templateParams.domainConfig.Add("postgresPasswordSecretName", $postgresConfigOutput["Postgres-PasswordSecretName"])
+            }
         }
         $templateParams.domainNetworkConfig = $CdfConfig.Domain.NetworkConfig ?? @{}
         $templateParams.domainAccessControl = $CdfConfig.Domain.AccessControl ?? @{}

--- a/CDFModule/Public/func_Deploy-TemplatePlatform.ps1
+++ b/CDFModule/Public/func_Deploy-TemplatePlatform.ps1
@@ -102,6 +102,8 @@
         # Add settings from the enterprise configuration for the spoke network / landing zone
         if ( $CdfConfig.Platform.SpokeNetworkConfig ) { $templateParams.enterpriseSpokeConfig = $CdfConfig.Platform.SpokeNetworkConfig }
 
+        # Add Public IP of Host for Postgres
+        if ( $CdfConfig.Platform.Features.enablePostgres ) {$templateParams.buildAgentIP = (Invoke-WebRequest ifconfig.me/ip).Content } else {$templateParams.buildAgentIP = ''}
         # TODO: Standardize this ugly workaround to provide DevOps Build Env Token
         if ( $env:PLATFORM_BUILDAGENT_PAT ) {
             $templateParams.platformEnv.platformDeploymentAccessToken = $env:PLATFORM_BUILDAGENT_PAT

--- a/CDFModule/Public/func_Deploy-TemplatePlatform.ps1
+++ b/CDFModule/Public/func_Deploy-TemplatePlatform.ps1
@@ -103,7 +103,7 @@
         if ( $CdfConfig.Platform.SpokeNetworkConfig ) { $templateParams.enterpriseSpokeConfig = $CdfConfig.Platform.SpokeNetworkConfig }
 
         # Add Public IP of Host for Postgres
-        if ( $CdfConfig.Platform.Features.enablePostgres ) {$templateParams.buildAgentIP = (Invoke-WebRequest ifconfig.me/ip).Content } else {$templateParams.buildAgentIP = ''}
+        #if ( $CdfConfig.Platform.Features.enablePostgres ) {$templateParams.buildAgentIP = (Invoke-WebRequest ifconfig.me/ip).Content } else {$templateParams.buildAgentIP = ''}
         # TODO: Standardize this ugly workaround to provide DevOps Build Env Token
         if ( $env:PLATFORM_BUILDAGENT_PAT ) {
             $templateParams.platformEnv.platformDeploymentAccessToken = $env:PLATFORM_BUILDAGENT_PAT


### PR DESCRIPTION
- To enable Flexible Postgres Server at Platform level
- Domain can use Platform Postgres Server to host its database.
- There will be one database and one user per domain. 
- Different services within domain will have its own schema. However, domain database user will be used by every domain service to access database.