### PR TITLE
Enviornment configuration in external config store

### DIFF
--- a/CDFModule/Public/func_Deploy-TemplateApplication.ps1
+++ b/CDFModule/Public/func_Deploy-TemplateApplication.ps1
@@ -175,6 +175,23 @@
             $CdfApplication = Get-Content -Path $configOutput | ConvertFrom-Json -AsHashtable
             $CdfApplication | ConvertTo-Json -Depth 10 | Write-Verbose
 
+            #Save to external config store
+            if ($CdfConfig.Platform.Config.configStoreType.ToUpper() -ne 'DEPLOYMENTOUTPUT') {
+                $regionDetails = [ordered] @{
+                    region = $region
+                    code   = $regionCode
+                    name   = $regionName
+                }
+                Save-ConfigToStore `
+                    -CdfConfig $CdfConfig `
+                    -ScopeConfig $CdfApplication `
+                    -Scope 'Application' `
+                    -OutputConfigFilePath $configOutput `
+                    -EnvKey "$($platformEnvKey)-$($applicationEnvKey)" `
+                    -RegionDetails $regionDetails `
+                    -ErrorAction Continue
+            }
+
             $CdfConfig.Application = $CdfApplication
             return $CdfConfig
         }

--- a/CDFModule/Public/func_Deploy-TemplateApplication.ps1
+++ b/CDFModule/Public/func_Deploy-TemplateApplication.ps1
@@ -176,7 +176,7 @@
             $CdfApplication | ConvertTo-Json -Depth 10 | Write-Verbose
 
             #Save to external config store
-            if ($CdfConfig.Platform.Config.configStoreType.ToUpper() -ne 'DEPLOYMENTOUTPUT') {
+            if ($CdfConfig.Platform.Config.configStoreType) {
                 $regionDetails = [ordered] @{
                     region = $region
                     code   = $regionCode

--- a/CDFModule/Public/func_Deploy-TemplateDomain.ps1
+++ b/CDFModule/Public/func_Deploy-TemplateDomain.ps1
@@ -187,7 +187,7 @@ Function Deploy-TemplateDomain {
             $CdfDomain = Get-Content -Path $configOutput | ConvertFrom-Json -AsHashtable
             $CdfDomain | ConvertTo-Json -Depth 10 | Write-Verbose
 
-            if ($CdfConfig.Platform.Config.configStoreType.ToUpper() -ne 'DEPLOYMENTOUTPUT') {
+            if ($CdfConfig.Platform.Config.configStoreType) {
                 $regionDetails = [ordered] @{
                     region = $region
                     code   = $regionCode

--- a/CDFModule/Public/func_Deploy-TemplateDomain.ps1
+++ b/CDFModule/Public/func_Deploy-TemplateDomain.ps1
@@ -187,6 +187,22 @@ Function Deploy-TemplateDomain {
             $CdfDomain = Get-Content -Path $configOutput | ConvertFrom-Json -AsHashtable
             $CdfDomain | ConvertTo-Json -Depth 10 | Write-Verbose
 
+            if ($CdfConfig.Platform.Config.configStoreType.ToUpper() -ne 'DEPLOYMENTOUTPUT') {
+                $regionDetails = [ordered] @{
+                    region = $region
+                    code   = $regionCode
+                    name   = $regionName
+                }
+                Save-ConfigToStore `
+                    -CdfConfig $CdfConfig `
+                    -ScopeConfig $CdfDomain `
+                    -Scope 'Domain' `
+                    -OutputConfigFilePath $configOutput `
+                    -EnvKey $platformEnvKey-$applicationEnvKey-$($CdfConfig.Domain.Config.domainName) `
+                    -RegionDetails $regionDetails `
+                    -ErrorAction Continue
+            }
+
             $CdfConfig.Domain = $CdfDomain
             return $CdfConfig
         }

--- a/CDFModule/Public/func_Deploy-TemplatePlatform.ps1
+++ b/CDFModule/Public/func_Deploy-TemplatePlatform.ps1
@@ -186,6 +186,22 @@
             $CdfPlatform | ConvertTo-Json -Depth 10 | Write-Verbose
             $CdfPlatform = Get-Content -Path $configOutput | ConvertFrom-Json -AsHashtable
 
+            #Save to external config store
+            if ($CdfConfig.Platform.Config.configStoreType.ToUpper() -ne 'DEPLOYMENTOUTPUT') {
+                $regionDetails = [ordered] @{
+                    region = $region
+                    code   = $regionCode
+                    name   = $regionName
+                }
+                Save-ConfigToStore `
+                    -CdfConfig $CdfConfig `
+                    -ScopeConfig $CdfPlatform `
+                    -Scope 'Platform' `
+                    -OutputConfigFilePath $configOutput `
+                    -EnvKey $platformEnvKey `
+                    -RegionDetails $regionDetails `
+                    -ErrorAction Continue
+            }
             $CdfConfig = [ordered] @{
                 Platform = $CdfPlatform
             }

--- a/CDFModule/Public/func_Deploy-TemplatePlatform.ps1
+++ b/CDFModule/Public/func_Deploy-TemplatePlatform.ps1
@@ -187,7 +187,7 @@
             $CdfPlatform = Get-Content -Path $configOutput | ConvertFrom-Json -AsHashtable
 
             #Save to external config store
-            if ($CdfConfig.Platform.Config.configStoreType.ToUpper() -ne 'DEPLOYMENTOUTPUT') {
+            if ($CdfConfig.Platform.Config.configStoreType) {
                 $regionDetails = [ordered] @{
                     region = $region
                     code   = $regionCode

--- a/CDFModule/Public/func_Deploy-TemplateService.ps1
+++ b/CDFModule/Public/func_Deploy-TemplateService.ps1
@@ -217,6 +217,21 @@
         $CdfService = Get-Content -Path $configOutput | ConvertFrom-Json -AsHashtable
         $CdfService | ConvertTo-Json -Depth 10 | Write-Verbose
 
+        if ($CdfConfig.Platform.Config.configStoreType.ToUpper() -ne 'DEPLOYMENTOUTPUT') {
+            $regionDetails = [ordered] @{
+                region = $region
+                code   = $regionCode
+                name   = $regionName
+            }
+            Save-ConfigToStore `
+                -CdfConfig $CdfConfig `
+                -ScopeConfig $CdfService `
+                -Scope 'Service' `
+                -OutputConfigFilePath $configOutput `
+                -EnvKey $platformEnvKey-$applicationEnvKey-$($CdfConfig.Domain.Config.domainName)-$ServiceName `
+                -RegionDetails $regionDetails `
+                -ErrorAction Continue
+        }
         $CdfConfig.Service = $CdfService
         return $CdfConfig
     }

--- a/CDFModule/Public/func_Deploy-TemplateService.ps1
+++ b/CDFModule/Public/func_Deploy-TemplateService.ps1
@@ -217,7 +217,7 @@
         $CdfService = Get-Content -Path $configOutput | ConvertFrom-Json -AsHashtable
         $CdfService | ConvertTo-Json -Depth 10 | Write-Verbose
 
-        if ($CdfConfig.Platform.Config.configStoreType.ToUpper() -ne 'DEPLOYMENTOUTPUT') {
+        if ($CdfConfig.Platform.Config.configStoreType) {
             $regionDetails = [ordered] @{
                 region = $region
                 code   = $regionCode

--- a/CDFModule/Public/func_Get-ConfigApplication.ps1
+++ b/CDFModule/Public/func_Get-ConfigApplication.ps1
@@ -113,7 +113,7 @@
     }
 
     if ($Deployed) {
-      if ($CdfConfig.Platform.Config.configStoreType.ToUpper() -ne 'DEPLOYMENTOUTPUT') {
+      if ($CdfConfig.Platform.Config.configStoreType) {
         $regionDetails = [ordered] @{
           region = $region
           code   = $regionCode
@@ -126,7 +126,7 @@
           -RegionDetails $regionDetails `
           -ErrorAction Continue
       }
-      if ($CdfConfig.Platform.Config.configStoreType.ToUpper() -eq 'DEPLOYMENTOUTPUT' -or ($cdfConfigOutput -ne $null -and $cdfConfigOutput.Count -eq 0)) {
+      if ($cdfConfigOutput -ne $null -and $cdfConfigOutput.Count -eq 0) {
 
         # Get latest deployment result outputs
         $deploymentName = "application-$platformEnvKey-$applicationEnvKey-$regionCode"

--- a/CDFModule/Public/func_Get-ConfigApplication.ps1
+++ b/CDFModule/Public/func_Get-ConfigApplication.ps1
@@ -107,6 +107,7 @@
       Write-Verbose "Loading configuration file"
       $CdfApplication = Get-Content "$sourcePath/application/application.$platformEnvKey-$applicationEnvKey-$regionCode.json" | ConvertFrom-Json -AsHashtable
       $CdfApplication.Env = $applicationEnv
+      $CdfApplication.ConfigSource = "FILE"
     }
     else {
       throw "No application configuration file found for platform key '$platformEnvKey', application key '$applicationEnvKey' and region code '$regionCode'."
@@ -150,6 +151,7 @@
             ResourceNames = $result.Outputs.applicationResourceNames.Value
             NetworkConfig = $result.Outputs.applicationNetworkConfig.Value
             AccessControl = $result.Outputs.applicationAccessControl.Value
+            ConfigSource = 'DEPLOYMENTOUTPUT'
           }
 
           # Convert to normalized hashtable
@@ -165,6 +167,7 @@
         }
       }
       else {
+        $cdfConfigOutput.Add("ConfigSource",$CdfConfig.Platform.Config.configStoreType.ToUpper())
         $CdfApplication = $cdfConfigOutput
       }
     }

--- a/CDFModule/Public/func_Get-ConfigApplication.ps1
+++ b/CDFModule/Public/func_Get-ConfigApplication.ps1
@@ -126,7 +126,7 @@
           -RegionDetails $regionDetails `
           -ErrorAction Continue
       }
-      if ($cdfConfigOutput -ne $null -and $cdfConfigOutput.Count -eq 0) {
+      if ($cdfConfigOutput -eq $null -or ($cdfConfigOutput -ne $null -and $cdfConfigOutput.Count -eq 0)) {
 
         # Get latest deployment result outputs
         $deploymentName = "application-$platformEnvKey-$applicationEnvKey-$regionCode"

--- a/CDFModule/Public/func_Get-ConfigDomain.ps1
+++ b/CDFModule/Public/func_Get-ConfigDomain.ps1
@@ -91,6 +91,21 @@
     }
 
     if ($Deployed) {
+      if ($CdfConfig.Platform.Config.configStoreType.ToUpper() -ne 'DEPLOYMENTOUTPUT') {
+        $regionDetails = [ordered] @{
+            region = $region
+            code   = $regionCode
+            name   = $regionName
+        }
+        $cdfConfigOutput = Get-ConfigFromStore `
+            -CdfConfig $CdfConfig `
+            -Scope 'Domain' `
+            -EnvKey "$platformEnvKey-$applicationEnvKey-$DomainName" `
+            -RegionDetails $regionDetails `
+            -ErrorAction Continue
+    }
+    if ($CdfConfig.Platform.Config.configStoreType.ToUpper() -eq 'DEPLOYMENTOUTPUT' -or ($cdfConfigOutput -ne $null -and  $cdfConfigOutput.Count -eq 0)) {
+
       # Get latest deployment result outputs
       $deploymentName = "domain-$platformEnvKey-$applicationEnvKey-$DomainName-$regionCode"
 
@@ -126,6 +141,10 @@
         Write-Warning "No deployment found for '$deploymentName' at '$region' using subscription [$($azCtx.Subscription.Name)] for runtime environment '$($applicationEnv.name)'."
         Write-Warning "Returning configuration from file."
       }
+    }
+    else{
+      $CdfDomain = $cdfConfigOutput
+    }
     }
     else {
       if ($CdfDomain.IsDeployed) {

--- a/CDFModule/Public/func_Get-ConfigDomain.ps1
+++ b/CDFModule/Public/func_Get-ConfigDomain.ps1
@@ -91,7 +91,7 @@
     }
 
     if ($Deployed) {
-      if ($CdfConfig.Platform.Config.configStoreType.ToUpper() -ne 'DEPLOYMENTOUTPUT') {
+      if ($CdfConfig.Platform.Config.configStoreType) {
         $regionDetails = [ordered] @{
             region = $region
             code   = $regionCode
@@ -104,7 +104,7 @@
             -RegionDetails $regionDetails `
             -ErrorAction Continue
     }
-    if ($CdfConfig.Platform.Config.configStoreType.ToUpper() -eq 'DEPLOYMENTOUTPUT' -or ($cdfConfigOutput -ne $null -and  $cdfConfigOutput.Count -eq 0)) {
+    if ($cdfConfigOutput -ne $null -and  $cdfConfigOutput.Count -eq 0) {
 
       # Get latest deployment result outputs
       $deploymentName = "domain-$platformEnvKey-$applicationEnvKey-$DomainName-$regionCode"

--- a/CDFModule/Public/func_Get-ConfigDomain.ps1
+++ b/CDFModule/Public/func_Get-ConfigDomain.ps1
@@ -79,6 +79,7 @@
     if (Test-Path "$sourcePath/domain/domain.$platformEnvKey-$applicationEnvKey-$DomainName-$regionCode.json" ) {
       Write-Verbose "Loading configuration file"
       $CdfDomain = Get-Content "$sourcePath/domain/domain.$platformEnvKey-$applicationEnvKey-$DomainName-$regionCode.json" | ConvertFrom-Json -AsHashtable
+      $CdfDomain.ConfigSource = "FILE"
     }
     else {
       Write-Warning "No domain configuration file found '$DomainName' with platform key '$platformEnvKey', application key '$applicationEnvKey' and region code '$regionCode'."
@@ -87,6 +88,7 @@
         Env        = [ordered] @{}
         Config     = [ordered] @{}
         Features   = [ordered] @{}
+        ConfigSource = "NO-SOURCE"
       }
     }
 
@@ -128,6 +130,7 @@
           ResourceNames = $result.Outputs.domainResourceNames.Value
           NetworkConfig = $result.Outputs.domainNetworkConfig.Value
           AccessControl = $result.Outputs.domainAccessControl.Value
+          ConfigSource = 'DEPLOYMENTOUTPUT'
         }
 
         # Convert to normalized hashtable
@@ -143,6 +146,7 @@
       }
     }
     else{
+      $cdfConfigOutput.Add("ConfigSource",$CdfConfig.Platform.Config.configStoreType.ToUpper())
       $CdfDomain = $cdfConfigOutput
     }
     }

--- a/CDFModule/Public/func_Get-ConfigDomain.ps1
+++ b/CDFModule/Public/func_Get-ConfigDomain.ps1
@@ -104,7 +104,7 @@
             -RegionDetails $regionDetails `
             -ErrorAction Continue
     }
-    if ($cdfConfigOutput -ne $null -and  $cdfConfigOutput.Count -eq 0) {
+    if ($cdfConfigOutput -eq $null -or ($cdfConfigOutput -ne $null -and $cdfConfigOutput.Count -eq 0)) {
 
       # Get latest deployment result outputs
       $deploymentName = "domain-$platformEnvKey-$applicationEnvKey-$DomainName-$regionCode"

--- a/CDFModule/Public/func_Get-ConfigFromStore.ps1
+++ b/CDFModule/Public/func_Get-ConfigFromStore.ps1
@@ -1,0 +1,151 @@
+﻿Function Get-ConfigFromStore {
+  <#
+    .SYNOPSIS
+    Get configuration from config store(AppConfig or keyVault or StorageAccount)
+
+    .DESCRIPTION
+    Retrieves the configuration for a deployed environment instance from config store.
+
+    .PARAMETER CdfConfig
+    Config object having config store and other details.
+
+    .PARAMETER Scope
+    Scope : Platform or Application or Domain or Service
+
+    .PARAMETER EnvKey
+    Env specific key to be used for fetching config.
+
+    .PARAMETER RegionDetails
+    Object having region details like name,code.
+
+    .INPUTS
+    None
+
+    .OUTPUTS
+    CdfConfigOutput
+
+    .EXAMPLE
+    Get-ConfigFromStore `
+          -CdfConfig $CdfPlatform `
+          -Scope 'Platform' `
+          -EnvKey $platformEnvKey `
+          -RegionDetails $regionDetails
+
+    .EXAMPLE
+    Get-ConfigFromStore `
+          -CdfConfig $CdfConfig `
+          -Scope 'Application' `
+          -EnvKey "$($platformEnvKey)-$($applicationEnvKey)" `
+          -RegionDetails $regionDetails `
+          -ErrorAction Continue
+
+    .LINK
+    Get-CdfConfigPlatform
+    .LINK
+    Get-CdfConfigApplication
+    .LINK
+    Get-CdfConfigDomain
+    .LINK
+    Get-CdfConfigService
+
+    #>
+
+  [CmdletBinding()]
+  Param(
+    [ValidateNotNullOrEmpty()]
+    [Parameter(Mandatory = $true)]
+    [hashtable]$CdfConfig,
+    [ValidateNotNullOrEmpty()]
+    [Parameter(Mandatory = $true)]
+    [string] $Scope,
+    [Parameter(Mandatory = $true)]
+    [string] $EnvKey,
+    [Parameter(Mandatory = $true)]
+    [hashtable] $RegionDetails
+  )
+  Begin {}
+  Process {
+    if ($Scope.ToUpper() -ne 'PLATFORM') {
+      $configStoreType = $CdfConfig.Platform.Config.configStoreType
+      $configStoreSubscriptionId = $CdfConfig.Platform.Config.configStoreSubscriptionId
+      $configStoreResourceGroupName = $CdfConfig.Platform.Config.configStoreResourceGroupName
+      $configStoreName = $CdfConfig.Platform.Config.configStoreName
+      $configStoreEndpoint = $CdfConfig.Platform.Config.configStoreEndpoint
+      $templateName = $CdfConfig.Platform.Config.templateName
+      $templateVersion = $CdfConfig.Platform.Config.templateVersion
+    }
+    else {
+      $configStoreType = $CdfConfig.Config.configStoreType
+      $configStoreSubscriptionId = $CdfConfig.Config.configStoreSubscriptionId
+      $configStoreResourceGroupName = $CdfConfig.Config.configStoreResourceGroupName
+      $configStoreName = $CdfConfig.Config.configStoreName
+      $configStoreEndpoint = $CdfConfig.Config.configStoreEndpoint
+      $templateName = $CdfConfig.Config.templateName
+      $templateVersion = $CdfConfig.Config.templateVersion
+    }
+    $keyName = "CdfConfig-$($Scope)-$EnvKey-$($RegionDetails.code)"
+
+    $azCtx = Get-AzureContext -SubscriptionId $configStoreSubscriptionId
+    Write-Verbose "Fetching config of '$($Scope.ToLower())' from custom config store '$configStoreName' in resource group '$configStoreResourceGroupName'  under subscription [$($azCtx.Subscription.Name)] with key '$EnvKey'."
+    $CdfConfigOutput = @{}
+    if ($configStoreType.ToUpper() -eq 'APPCONFIG') {
+      $lableName = "$templateName-$templateVersion"
+      $result = Get-AzAppConfigurationKeyValue -EndPoint $configStoreEndpoint -Label $lableName | Select-Object Key, Value
+      if ($result) {
+        $CdfConfigOutput = [ordered] @{
+          IsDeployed    = $true
+          Env           = ($result | Where-Object { $_.Key -eq "$($keyName)-Env" }).Value | ConvertFrom-Json -AsHashtable
+          Tags          = ($result | Where-Object { $_.Key -eq "$($keyName)-Tags" }).Value | ConvertFrom-Json -AsHashtable
+          Config        = ($result | Where-Object { $_.Key -eq "$($keyName)-Config" }).Value | ConvertFrom-Json -AsHashtable
+          Features      = ($result | Where-Object { $_.Key -eq "$($keyName)-Features" }).Value | ConvertFrom-Json -AsHashtable
+          ResourceNames = ($result | Where-Object { $_.Key -eq "$($keyName)-ResourceNames" }).Value | ConvertFrom-Json -AsHashtable
+          AccessControl = ($result | Where-Object { $_.Key -eq "$($keyName)-AccessControl" }).Value | ConvertFrom-Json -AsHashtable
+          NetworkConfig = ($result | Where-Object { $_.Key -eq "$($keyName)-NetworkConfig" }).Value | ConvertFrom-Json -AsHashtable
+
+        }
+        $CdfConfigOutput = $CdfConfigOutput | ConvertTo-Json -depth 10 | ConvertFrom-Json -AsHashtable
+      }
+      else {
+        Write-Warning "No configuration found in custom config store '$configStoreName' with label '$lableName' in resource group '$configStoreResourceGroupName' using subscription [$($azCtx.Subscription.Name)] for runtime environment '$($EnvDetails.nameId)'."
+        Write-Warning "Trying to retrun configuration from deployment output."
+      }
+
+    }
+    elseif ($configStoreType.ToUpper() -eq 'KEYVAULT') {
+      $result = Get-AzKeyVaultSecret `
+        -VaultName $configStoreName `
+        -Name $keyName `
+        -AsPlainText
+      if ($result) {
+        $CdfConfigOutput = $result | ConvertFrom-Json -AsHashtable
+      }
+      else {
+        Write-Warning "No configuration found in KeyVault '$configStoreName' with key '$keyName' in resource group '$configStoreResourceGroupName' using subscription [$($azCtx.Subscription.Name)]."
+        Write-Warning "Trying to retrun configuration from deployment output."
+      }
+
+    }
+    elseif ($configStoreType.ToUpper() -eq 'STORAGEACCOUNT') {
+      $azStorageCtx = New-AzStorageContext -StorageAccountName $configStoreName -UseConnectedAccount
+      $containerName = 'cdfconfig'
+      $blob = Get-AzStorageBlob -Container $containerName -Blob $keyName -Context $azStorageCtx
+      if ($blob) {
+        $stream = $blob.ICloudBlob.OpenRead()
+        $reader = New-Object System.IO.StreamReader($stream)
+        $result = $reader.ReadToEnd()
+        $reader.Close()
+        $stream.Close()
+        $CdfConfigOutput = $result | ConvertFrom-Json -AsHashtable
+      }
+      else {
+        Write-Warning "No configuration found in Storage Account '$configStoreName' and container '$containerName'  with blob name '$keyName' in subscription [$($azCtx.Subscription.Name)]."
+        Write-Warning "Trying to retrun configuration from deployment output."
+      }
+    }
+    return $CdfConfigOutput;
+  }
+
+  End {
+  }
+}
+

--- a/CDFModule/Public/func_Get-ConfigFromStore.ps1
+++ b/CDFModule/Public/func_Get-ConfigFromStore.ps1
@@ -106,8 +106,8 @@
         $CdfConfigOutput = $CdfConfigOutput | ConvertTo-Json -depth 10 | ConvertFrom-Json -AsHashtable
       }
       else {
-        Write-Warning "No configuration found in custom config store '$configStoreName' with label '$lableName' in resource group '$configStoreResourceGroupName' using subscription [$($azCtx.Subscription.Name)] for runtime environment '$($EnvDetails.nameId)'."
-        Write-Warning "Trying to retrun configuration from deployment output."
+        Write-Warning "No configuration found in custom config store '$configStoreName' with label '$lableName' in resource group '$configStoreResourceGroupName' under subscription [$($azCtx.Subscription.Name)] with key '$EnvKey'."
+        Write-Warning "Trying to return configuration from deployment output."
       }
 
     }
@@ -121,7 +121,7 @@
       }
       else {
         Write-Warning "No configuration found in KeyVault '$configStoreName' with key '$keyName' in resource group '$configStoreResourceGroupName' using subscription [$($azCtx.Subscription.Name)]."
-        Write-Warning "Trying to retrun configuration from deployment output."
+        Write-Warning "Trying to return configuration from deployment output."
       }
 
     }
@@ -139,7 +139,7 @@
       }
       else {
         Write-Warning "No configuration found in Storage Account '$configStoreName' and container '$containerName'  with blob name '$keyName' in subscription [$($azCtx.Subscription.Name)]."
-        Write-Warning "Trying to retrun configuration from deployment output."
+        Write-Warning "Trying to return configuration from deployment output."
       }
     }
     return $CdfConfigOutput;

--- a/CDFModule/Public/func_Get-ConfigPlatform.ps1
+++ b/CDFModule/Public/func_Get-ConfigPlatform.ps1
@@ -109,40 +109,59 @@
     }
 
     if ($Deployed) {
-      # Get latest deployment result outputs
-      $deploymentName = "platform-$platformEnvKey-$regionCode"
 
-      $azCtx = Get-AzureContext -SubscriptionId $CdfPlatform.Env.subscriptionId
-      Write-Verbose "Fetching deployment of '$deploymentName' at '$region' using subscription [$($azCtx.Subscription.Name)] for runtime environment '$($platformEnv.name)'."
-
-      $result = Get-AzSubscriptionDeployment  `
-        -DefaultProfile $azCtx `
-        -Name "$deploymentName" `
-        -ErrorAction SilentlyContinue
-
-      if ($result -and $result.ProvisioningState -eq 'Succeeded') {
-        # Setup platform definitions
-        $CdfPlatform = [ordered] @{
-          IsDeployed    = $true
-          Env           = $result.Outputs.platformEnv.Value
-          Tags          = $result.Outputs.platformTags.Value
-          Config        = $result.Outputs.platformConfig.Value
-          Features      = $result.Outputs.platformFeatures.Value
-          ResourceNames = $result.Outputs.platformResourceNames.Value
-          NetworkConfig = $result.Outputs.platformNetworkConfig.Value
-          AccessControl = $result.Outputs.platformAccessControl.Value
+      if ($CdfPlatform.Config.configStoreType.ToUpper() -ne 'DEPLOYMENTOUTPUT') {
+        $regionDetails = [ordered] @{
+          region = $region
+          code   = $regionCode
+          name   = $regionName
         }
-
-        # Convert to normalized hashtable
-        $CdfPlatform = $CdfPlatform | ConvertTo-Json -depth 10 | ConvertFrom-Json -AsHashtable
+        $cdfConfigOutput = Get-ConfigFromStore `
+          -CdfConfig $CdfPlatform `
+          -Scope 'Platform' `
+          -EnvKey $platformEnvKey `
+          -RegionDetails $regionDetails `
+          -ErrorAction Continue
       }
-      elseif ($result -and $result.ProvisioningState -ne 'Succeeded') {
-        Write-Warning "Deployment state is [$($result.ProvisioningState)] for '$deploymentName' at '$region' using subscription [$($azCtx.Subscription.Name)] for runtime environment '$($applicationEnv.name)'."
-        Write-Warning "Returning configuration from file."
+
+      if ($CdfPlatform.Config.configStoreType.ToUpper() -eq 'DEPLOYMENTOUTPUT' -or ($cdfConfigOutput -ne $null -and $cdfConfigOutput.Count -eq 0)) {
+        # Get latest deployment result outputs
+        $deploymentName = "platform-$platformEnvKey-$regionCode"
+
+        $azCtx = Get-AzureContext -SubscriptionId $CdfPlatform.Env.subscriptionId
+        Write-Verbose "Fetching deployment of '$deploymentName' at '$region' using subscription [$($azCtx.Subscription.Name)] for runtime environment '$($platformEnv.name)'."
+
+        $result = Get-AzSubscriptionDeployment  `
+          -DefaultProfile $azCtx `
+          -Name "$deploymentName" `
+          -ErrorAction SilentlyContinue
+
+        if ($result -and $result.ProvisioningState -eq 'Succeeded') {
+          # Setup platform definitions
+          $CdfPlatform = [ordered] @{
+            IsDeployed    = $true
+            Env           = $result.Outputs.platformEnv.Value
+            Tags          = $result.Outputs.platformTags.Value
+            Config        = $result.Outputs.platformConfig.Value
+            Features      = $result.Outputs.platformFeatures.Value
+            ResourceNames = $result.Outputs.platformResourceNames.Value
+            NetworkConfig = $result.Outputs.platformNetworkConfig.Value
+            AccessControl = $result.Outputs.platformAccessControl.Value
+          }
+          # Convert to normalized hashtable
+          $CdfPlatform = $CdfPlatform | ConvertTo-Json -depth 10 | ConvertFrom-Json -AsHashtable
+        }
+        elseif ($result -and $result.ProvisioningState -ne 'Succeeded') {
+          Write-Warning "Deployment state is [$($result.ProvisioningState)] for '$deploymentName' at '$region' using subscription [$($azCtx.Subscription.Name)] for runtime environment '$($applicationEnv.name)'."
+          Write-Warning "Returning configuration from file."
+        }
+        else {
+          Write-Warning "No deployment found for '$deploymentName' at '$region' using subscription [$($azCtx.Subscription.Name)] for runtime environment '$($platformEnv.name)'."
+          Write-Warning "Returning configuration from file."
+        }
       }
       else {
-        Write-Warning "No deployment found for '$deploymentName' at '$region' using subscription [$($azCtx.Subscription.Name)] for runtime environment '$($platformEnv.name)'."
-        Write-Warning "Returning configuration from file."
+        $CdfPlatform = $cdfConfigOutput
       }
     }
 
@@ -153,7 +172,6 @@
         Write-Verbose "Loading enterprise spoke network configuration"
         $CdfPlatform.SpokeNetworkConfig = Get-Content "$sourcePath/platform/spokeconfig.$platformEnvKey-$regionCode.json" | ConvertFrom-Json -AsHashtable
       }
-
       # Update platform configuration with current settings
       $CdfPlatform.Env.region = $region
       $CdfPlatform.Env.regionCode = $regionCode

--- a/CDFModule/Public/func_Get-ConfigPlatform.ps1
+++ b/CDFModule/Public/func_Get-ConfigPlatform.ps1
@@ -98,6 +98,7 @@
       Write-Verbose "Loading configuration from output json"
       $CdfPlatform = Get-Content  $platformConfigFile | ConvertFrom-Json -AsHashtable
       $CdfPlatform.Env = $platformEnv
+      $CdfPlatform.ConfigSource = "FILE"
     }
     else {
       Write-Error "Platform configuration file not found. Path: $platformConfigFile"
@@ -147,6 +148,7 @@
             ResourceNames = $result.Outputs.platformResourceNames.Value
             NetworkConfig = $result.Outputs.platformNetworkConfig.Value
             AccessControl = $result.Outputs.platformAccessControl.Value
+            ConfigSource = 'DEPLOYMENTOUTPUT'
           }
           # Convert to normalized hashtable
           $CdfPlatform = $CdfPlatform | ConvertTo-Json -depth 10 | ConvertFrom-Json -AsHashtable
@@ -161,6 +163,7 @@
         }
       }
       else {
+        $cdfConfigOutput.Add("ConfigSource",$CdfPlatform.Config.configStoreType.ToUpper())
         $CdfPlatform = $cdfConfigOutput
       }
     }

--- a/CDFModule/Public/func_Get-ConfigPlatform.ps1
+++ b/CDFModule/Public/func_Get-ConfigPlatform.ps1
@@ -112,6 +112,11 @@
     if ($Deployed) {
 
       if ($CdfPlatform.Config.configStoreType) {
+        $configStoreType = $CdfPlatform.Config.configStoreType
+        $configStoreSubscriptionId = $CdfPlatform.Config.configStoreSubscriptionId
+        $configStoreResourceGroupName = $CdfPlatform.Config.configStoreResourceGroupName
+        $configStoreName = $CdfPlatform.Config.configStoreName
+        $configStoreEndpoint = $CdfPlatform.Config.configStoreEndpoint
         $regionDetails = [ordered] @{
           region = $region
           code   = $regionCode
@@ -148,7 +153,7 @@
             ResourceNames = $result.Outputs.platformResourceNames.Value
             NetworkConfig = $result.Outputs.platformNetworkConfig.Value
             AccessControl = $result.Outputs.platformAccessControl.Value
-            ConfigSource = 'DEPLOYMENTOUTPUT'
+            ConfigSource  = 'DEPLOYMENTOUTPUT'
           }
           # Convert to normalized hashtable
           $CdfPlatform = $CdfPlatform | ConvertTo-Json -depth 10 | ConvertFrom-Json -AsHashtable
@@ -163,7 +168,7 @@
         }
       }
       else {
-        $cdfConfigOutput.Add("ConfigSource",$CdfPlatform.Config.configStoreType.ToUpper())
+        $cdfConfigOutput.Add("ConfigSource", $CdfPlatform.Config.configStoreType.ToUpper())
         $CdfPlatform = $cdfConfigOutput
       }
     }
@@ -182,7 +187,13 @@
       $CdfPlatform.Config.templateScope = 'platform'
       $CdfPlatform.Config.platformId = $PlatformId
       $CdfPlatform.Config.instanceId = $InstanceId
-
+      if ($configStoreType) {
+        $CdfPlatform.Config.configStoreType = $configStoreType
+        $CdfPlatform.Config.configStoreSubscriptionId = $configStoreSubscriptionId
+        $CdfPlatform.Config.configStoreResourceGroupName = $configStoreResourceGroupName
+        $CdfPlatform.Config.configStoreName = $configStoreName
+        $CdfPlatform.Config.configStoreEndpoint = $configStoreEndpoint
+      }
       $CdfPlatform | ConvertTo-Json -Depth 10 | Write-Verbose
 
       $CdfConfig = [ordered] @{

--- a/CDFModule/Public/func_Get-ConfigPlatform.ps1
+++ b/CDFModule/Public/func_Get-ConfigPlatform.ps1
@@ -110,7 +110,7 @@
 
     if ($Deployed) {
 
-      if ($CdfPlatform.Config.configStoreType.ToUpper() -ne 'DEPLOYMENTOUTPUT') {
+      if ($CdfPlatform.Config.configStoreType) {
         $regionDetails = [ordered] @{
           region = $region
           code   = $regionCode
@@ -124,7 +124,7 @@
           -ErrorAction Continue
       }
 
-      if ($CdfPlatform.Config.configStoreType.ToUpper() -eq 'DEPLOYMENTOUTPUT' -or ($cdfConfigOutput -ne $null -and $cdfConfigOutput.Count -eq 0)) {
+      if ($cdfConfigOutput -ne $null -and $cdfConfigOutput.Count -eq 0) {
         # Get latest deployment result outputs
         $deploymentName = "platform-$platformEnvKey-$regionCode"
 

--- a/CDFModule/Public/func_Get-ConfigPlatform.ps1
+++ b/CDFModule/Public/func_Get-ConfigPlatform.ps1
@@ -124,7 +124,7 @@
           -ErrorAction Continue
       }
 
-      if ($cdfConfigOutput -ne $null -and $cdfConfigOutput.Count -eq 0) {
+      if ($cdfConfigOutput -eq $null -or ($cdfConfigOutput -ne $null -and $cdfConfigOutput.Count -eq 0)) {
         # Get latest deployment result outputs
         $deploymentName = "platform-$platformEnvKey-$regionCode"
 

--- a/CDFModule/Public/func_Get-ConfigService.ps1
+++ b/CDFModule/Public/func_Get-ConfigService.ps1
@@ -104,6 +104,21 @@
     }
 
     if ($Deployed) {
+      if ($CdfConfig.Platform.Config.configStoreType.ToUpper() -ne 'DEPLOYMENTOUTPUT') {
+        $regionDetails = [ordered] @{
+            region = $region
+            code   = $regionCode
+            name   = $regionName
+        }
+        $cdfConfigOutput = Get-ConfigFromStore `
+            -CdfConfig $CdfConfig `
+            -Scope 'Service' `
+            -EnvKey "$platformEnvKey-$applicationEnvKey-$DomainName-$ServiceName" `
+            -RegionDetails $regionDetails `
+            -ErrorAction Continue
+    }
+    if ($CdfConfig.Platform.Config.configStoreType.ToUpper() -eq 'DEPLOYMENTOUTPUT' -or ($cdfConfigOutput -ne $null -and  $cdfConfigOutput.Count -eq 0)) {
+
       # Get latest deployment result outputs
       $deploymentName = "service-$platformEnvKey-$applicationEnvKey-$($CdfConfig.Domain.Config.domainName)-$ServiceName-$regionCode"
 
@@ -151,6 +166,10 @@
           Write-Warning "Returning service configuration from file, if available."
         }
       }
+    }
+    else{
+      $CdfService = $cdfConfigOutput
+    }
     }
     else {
       if ($CdfService.IsDeployed) {

--- a/CDFModule/Public/func_Get-ConfigService.ps1
+++ b/CDFModule/Public/func_Get-ConfigService.ps1
@@ -91,7 +91,7 @@
           serviceTemplate = $serviceConfig.ServiceDefaults.ServiceTemplate
         }
         Features   = [ordered] @{}
-        $CdfService.ConfigSource = "FILE"
+        ConfigSource = "FILE"
       }
     }
     else {

--- a/CDFModule/Public/func_Get-ConfigService.ps1
+++ b/CDFModule/Public/func_Get-ConfigService.ps1
@@ -104,7 +104,7 @@
     }
 
     if ($Deployed) {
-      if ($CdfConfig.Platform.Config.configStoreType.ToUpper() -ne 'DEPLOYMENTOUTPUT') {
+      if ($CdfConfig.Platform.Config.configStoreType) {
         $regionDetails = [ordered] @{
             region = $region
             code   = $regionCode
@@ -117,7 +117,7 @@
             -RegionDetails $regionDetails `
             -ErrorAction Continue
     }
-    if ($CdfConfig.Platform.Config.configStoreType.ToUpper() -eq 'DEPLOYMENTOUTPUT' -or ($cdfConfigOutput -ne $null -and  $cdfConfigOutput.Count -eq 0)) {
+    if ($cdfConfigOutput -ne $null -and  $cdfConfigOutput.Count -eq 0) {
 
       # Get latest deployment result outputs
       $deploymentName = "service-$platformEnvKey-$applicationEnvKey-$($CdfConfig.Domain.Config.domainName)-$ServiceName-$regionCode"

--- a/CDFModule/Public/func_Get-ConfigService.ps1
+++ b/CDFModule/Public/func_Get-ConfigService.ps1
@@ -91,6 +91,7 @@
           serviceTemplate = $serviceConfig.ServiceDefaults.ServiceTemplate
         }
         Features   = [ordered] @{}
+        $CdfService.ConfigSource = "FILE"
       }
     }
     else {
@@ -100,6 +101,7 @@
         Env        = [ordered] @{}
         Config     = [ordered] @{}
         Features   = [ordered] @{}
+        ConfigSource = "NO-SOURCE"
       }
     }
 
@@ -148,6 +150,7 @@
           ResourceNames = $result.Outputs.serviceResourceNames.Value
           NetworkConfig = $result.Outputs.serviceNetworkConfig.Value
           AccessControl = $result.Outputs.serviceAccessControl.Value
+          ConfigSource = 'DEPLOYMENTOUTPUT'
         }
 
         # Convert to normalized hashtable
@@ -168,6 +171,7 @@
       }
     }
     else{
+      $cdfConfigOutput.Add("ConfigSource",$CdfConfig.Platform.Config.configStoreType.ToUpper())
       $CdfService = $cdfConfigOutput
     }
     }

--- a/CDFModule/Public/func_Get-ConfigService.ps1
+++ b/CDFModule/Public/func_Get-ConfigService.ps1
@@ -117,7 +117,7 @@
             -RegionDetails $regionDetails `
             -ErrorAction Continue
     }
-    if ($cdfConfigOutput -ne $null -and  $cdfConfigOutput.Count -eq 0) {
+    if ($cdfConfigOutput -eq $null -or ($cdfConfigOutput -ne $null -and $cdfConfigOutput.Count -eq 0)) {
 
       # Get latest deployment result outputs
       $deploymentName = "service-$platformEnvKey-$applicationEnvKey-$($CdfConfig.Domain.Config.domainName)-$ServiceName-$regionCode"

--- a/CDFModule/Public/func_Remove-ConfigFromStore.ps1
+++ b/CDFModule/Public/func_Remove-ConfigFromStore.ps1
@@ -1,0 +1,115 @@
+﻿Function Remove-ConfigFromStore {
+  <#
+    .SYNOPSIS
+    Remove configuration from config store(AppConfig or keyVault or StorageAccount)
+
+    .DESCRIPTION
+    Removes configuration for a deployed environment instance from config store.
+
+    .PARAMETER CdfConfig
+    Config object having config store and other details.
+
+    .PARAMETER Scope
+    Scope : Platform or Application or Domain or Service
+
+    .PARAMETER EnvKey
+    Env specific key to be used for fetching config.
+
+    .PARAMETER RegionDetails
+    Object having region details like name,code.
+
+    .INPUTS
+    None
+
+    .OUTPUTS
+    CdfConfigOutput
+
+    .EXAMPLE
+    Remove-ConfigFromStore `
+          -CdfConfig $CdfPlatform `
+          -Scope 'Platform' `
+          -EnvKey $platformEnvKey `
+          -RegionDetails $regionDetails
+
+    .EXAMPLE
+    Remove-ConfigFromStore `
+          -CdfConfig $CdfConfig `
+          -Scope 'Application' `
+          -EnvKey "$($platformEnvKey)-$($applicationEnvKey)" `
+          -RegionDetails $regionDetails `
+          -ErrorAction Continue
+
+    .LINK
+    Remove-CdfConfigPlatform
+    .LINK
+    Remove-CdfConfigApplication
+    .LINK
+    Remove-CdfConfigDomain
+    .LINK
+    Remove-CdfConfigService
+
+    #>
+
+  [CmdletBinding()]
+  Param(
+    [ValidateNotNullOrEmpty()]
+    [Parameter(Mandatory = $true)]
+    [hashtable]$CdfConfig,
+    [ValidateNotNullOrEmpty()]
+    [Parameter(Mandatory = $true)]
+    [string] $Scope,
+    [Parameter(Mandatory = $true)]
+    [string] $EnvKey,
+    [Parameter(Mandatory = $true)]
+    [hashtable] $RegionDetails
+  )
+  Begin {}
+  Process {
+    if ($Scope.ToUpper() -ne 'PLATFORM') {
+      $configStoreType = $CdfConfig.Platform.Config.configStoreType
+      $configStoreSubscriptionId = $CdfConfig.Platform.Config.configStoreSubscriptionId
+      $configStoreResourceGroupName = $CdfConfig.Platform.Config.configStoreResourceGroupName
+      $configStoreName = $CdfConfig.Platform.Config.configStoreName
+      $configStoreEndpoint = $CdfConfig.Platform.Config.configStoreEndpoint
+      $templateName = $CdfConfig.Platform.Config.templateName
+      $templateVersion = $CdfConfig.Platform.Config.templateVersion
+    }
+    else {
+      $configStoreType = $CdfConfig.Config.configStoreType
+      $configStoreSubscriptionId = $CdfConfig.Config.configStoreSubscriptionId
+      $configStoreResourceGroupName = $CdfConfig.Config.configStoreResourceGroupName
+      $configStoreName = $CdfConfig.Config.configStoreName
+      $configStoreEndpoint = $CdfConfig.Config.configStoreEndpoint
+      $templateName = $CdfConfig.Config.templateName
+      $templateVersion = $CdfConfig.Config.templateVersion
+    }
+    $keyName = "CdfConfig-$($Scope)-$EnvKey-$($RegionDetails.code)"
+
+    $azCtx = Get-AzureContext -SubscriptionId $configStoreSubscriptionId
+    Write-Host "Removing config of '$($Scope.ToLower())' from custom config store '$configStoreName' in resource group '$configStoreResourceGroupName'  under subscription [$($azCtx.Subscription.Name)] with key '$EnvKey'."
+    $CdfConfigOutput = @{}
+    if ($configStoreType.ToUpper() -eq 'APPCONFIG') {
+      $configNames = @("Config", "Env", "Tags", "Features", "NetworkConfig", "AccessControl", "ResourceNames")
+            foreach ($configName in $configNames) {
+                $null = Remove-AzAppConfigurationKeyValue `
+                    -Endpoint $configStoreEndpoint `
+                    -Key "$keyName-$configName" `
+                    -Label  "$templateName-$templateVersion"
+            }
+    }
+    elseif ($configStoreType.ToUpper() -eq 'KEYVAULT') {
+      $null = Remove-AzKeyVaultSecret `
+        -VaultName $configStoreName `
+        -Name $keyName
+    }
+    elseif ($configStoreType.ToUpper() -eq 'STORAGEACCOUNT') {
+      $azStorageCtx = New-AzStorageContext -StorageAccountName $configStoreName -UseConnectedAccount
+      $containerName = 'cdfconfig'
+      $null = Remove-AzStorageBlob -Container $containerName -Blob $keyName -Context $azStorageCtx
+    }
+  }
+
+  End {
+  }
+}
+

--- a/CDFModule/Public/func_Remove-TemplateApplication.ps1
+++ b/CDFModule/Public/func_Remove-TemplateApplication.ps1
@@ -304,7 +304,7 @@
             Write-Host "-- End Phase #3"
         }
 
-        if ($CdfConfig.Platform.Config.configStoreType.ToUpper() -ne 'DEPLOYMENTOUTPUT' -and $false -eq $DryRun) {
+        if ($CdfConfig.Platform.Config.configStoreType -and $false -eq $DryRun) {
             $regionDetails = [ordered] @{
               region = $region
               code   = $regionCode

--- a/CDFModule/Public/func_Remove-TemplateApplication.ps1
+++ b/CDFModule/Public/func_Remove-TemplateApplication.ps1
@@ -304,6 +304,20 @@
             Write-Host "-- End Phase #3"
         }
 
+        if ($CdfConfig.Platform.Config.configStoreType.ToUpper() -ne 'DEPLOYMENTOUTPUT' -and $false -eq $DryRun) {
+            $regionDetails = [ordered] @{
+              region = $region
+              code   = $regionCode
+              name   = $region
+            }
+            Remove-ConfigFromStore `
+              -CdfConfig $CdfConfig `
+              -Scope 'Application' `
+              -EnvKey $platformEnvKey-$applicationEnvKey `
+              -RegionDetails $regionDetails `
+              -ErrorAction Continue
+          }
+
         Write-Host "Completed."
     }
     End {

--- a/CDFModule/Public/func_Remove-TemplateDomain.ps1
+++ b/CDFModule/Public/func_Remove-TemplateDomain.ps1
@@ -215,6 +215,19 @@ Function Remove-TemplateDomain {
                     -Name $deploymentName `
                     -ErrorAction SilentlyContinue
             }
+            if ($CdfConfig.Platform.Config.configStoreType.ToUpper() -ne 'DEPLOYMENTOUTPUT' -and $false -eq $DryRun) {
+                $regionDetails = [ordered] @{
+                  region = $region
+                  code   = $regionCode
+                  name   = $region
+                }
+                Remove-ConfigFromStore `
+                  -CdfConfig $CdfConfig `
+                  -Scope 'Domain' `
+                  -EnvKey $platformEnvKey-$applicationEnvKey-$($CdfConfig.Domain.Config.domainName) `
+                  -RegionDetails $regionDetails `
+                  -ErrorAction Continue
+              }
         }
         catch {
             Write-Error $_

--- a/CDFModule/Public/func_Remove-TemplateDomain.ps1
+++ b/CDFModule/Public/func_Remove-TemplateDomain.ps1
@@ -215,7 +215,7 @@ Function Remove-TemplateDomain {
                     -Name $deploymentName `
                     -ErrorAction SilentlyContinue
             }
-            if ($CdfConfig.Platform.Config.configStoreType.ToUpper() -ne 'DEPLOYMENTOUTPUT' -and $false -eq $DryRun) {
+            if ($CdfConfig.Platform.Config.configStoreType -and $false -eq $DryRun) {
                 $regionDetails = [ordered] @{
                   region = $region
                   code   = $regionCode

--- a/CDFModule/Public/func_Remove-TemplatePlatform.ps1
+++ b/CDFModule/Public/func_Remove-TemplatePlatform.ps1
@@ -275,6 +275,20 @@
             }
             Write-Host " Done."
         }
+
+        if ($CdfConfig.Platform.Config.configStoreType.ToUpper() -ne 'DEPLOYMENTOUTPUT' -and $false -eq $DryRun) {
+            $regionDetails = [ordered] @{
+              region = $region
+              code   = $regionCode
+              name   = $region
+            }
+            Remove-ConfigFromStore `
+              -CdfConfig $CdfConfig `
+              -Scope 'Platform' `
+              -EnvKey $platformEnvKey `
+              -RegionDetails $regionDetails `
+              -ErrorAction Continue
+          }
     }
     End {
     }

--- a/CDFModule/Public/func_Remove-TemplatePlatform.ps1
+++ b/CDFModule/Public/func_Remove-TemplatePlatform.ps1
@@ -276,7 +276,7 @@
             Write-Host " Done."
         }
 
-        if ($CdfConfig.Platform.Config.configStoreType.ToUpper() -ne 'DEPLOYMENTOUTPUT' -and $false -eq $DryRun) {
+        if ($CdfConfig.Platform.Config.configStoreType -and $false -eq $DryRun) {
             $regionDetails = [ordered] @{
               region = $region
               code   = $regionCode

--- a/CDFModule/Public/func_Remove-TemplateService.ps1
+++ b/CDFModule/Public/func_Remove-TemplateService.ps1
@@ -210,7 +210,7 @@ Function Remove-TemplateService {
                     -Name $deploymentName `
                     -ErrorAction SilentlyContinue
             }
-            if ($CdfConfig.Platform.Config.configStoreType.ToUpper() -ne 'DEPLOYMENTOUTPUT' -and $false -eq $DryRun) {
+            if ($CdfConfig.Platform.Config.configStoreType -and $false -eq $DryRun) {
                 $regionDetails = [ordered] @{
                   region = $region
                   code   = $regionCode

--- a/CDFModule/Public/func_Remove-TemplateService.ps1
+++ b/CDFModule/Public/func_Remove-TemplateService.ps1
@@ -210,6 +210,19 @@ Function Remove-TemplateService {
                     -Name $deploymentName `
                     -ErrorAction SilentlyContinue
             }
+            if ($CdfConfig.Platform.Config.configStoreType.ToUpper() -ne 'DEPLOYMENTOUTPUT' -and $false -eq $DryRun) {
+                $regionDetails = [ordered] @{
+                  region = $region
+                  code   = $regionCode
+                  name   = $region
+                }
+                Remove-ConfigFromStore `
+                  -CdfConfig $CdfConfig `
+                  -Scope 'Service' `
+                  -EnvKey $platformEnvKey-$applicationEnvKey-$($CdfConfig.Domain.Config.domainName)-$($CdfConfig.Service.Config.serviceName) `
+                  -RegionDetails $regionDetails `
+                  -ErrorAction Continue
+              }
         }
         catch {
             Write-Error $_

--- a/CDFModule/Public/func_Save-ConfigToStore.ps1
+++ b/CDFModule/Public/func_Save-ConfigToStore.ps1
@@ -1,0 +1,128 @@
+﻿Function Save-ConfigToStore {
+    <#
+    .SYNOPSIS
+    Save configuration to config store(AppConfig or keyVault or StorageAccount)
+
+    .DESCRIPTION
+    Saves the configuration for a deployed environment instance in a config store.
+
+    .PARAMETER CdfConfig
+    Config object having config store and other details.
+
+    .PARAMETER ScopeConfig
+    Object having config for env in scope..
+
+    .PARAMETER Scope
+    Scope : Platform or Application or Domain or Service
+
+    .PARAMETER EnvKey
+    Env specific key to be used for fetching config.
+
+    .PARAMETER OutputConfigFilePath
+    Json file path to be uploaded to blob in case config store is StorageAccount
+
+    .PARAMETER RegionDetails
+    Object having region details like name,code.
+
+    .INPUTS
+    CdfConfig
+
+    .OUTPUTS
+    Updated CDFConfig and json config files at SourceDir
+
+
+    .EXAMPLE
+    $regionDetails = [ordered] @{
+                    region = $region
+                    code   = $regionCode
+                    name   = $regionName
+                }
+    Save-ConfigToStore `
+                    -CdfConfig $CdfConfig `
+                    -ScopeConfig $CdfApplication `
+                    -Scope 'Application' `
+                    -OutputConfigFilePath $configOutput `
+                    -EnvKey "$($platformEnvKey)-$($applicationEnvKey)" `
+                    -RegionDetails $regionDetails
+
+
+    .LINK
+    Remove-CdfTemplatePlatform
+    .LINK
+    Deploy-CdfTemplatePlatform
+    .LINK
+    Deploy-CdfTemplateApplication
+    .LINK
+    Deploy-CdfTemplateDomain
+    .LINK
+    Deploy-CdfTemplateService
+
+    #>
+
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory = $true)]
+        [Object]$CdfConfig,
+        [Parameter(Mandatory = $true)]
+        [Object]$ScopeConfig,
+        [Parameter(Mandatory = $true)]
+        [string] $Scope,
+        [Parameter(Mandatory = $true)]
+        [string] $OutputConfigFilePath,
+        [Parameter(Mandatory = $true)]
+        [string] $EnvKey,
+        [Parameter(Mandatory = $true)]
+        [hashtable] $RegionDetails
+    )
+
+    Begin {
+    }
+    Process {
+
+        $configStoreType = $CdfConfig.Platform.Config.configStoreType
+        $configStoreSubscriptionId = $CdfConfig.Platform.Config.configStoreSubscriptionId
+        $configStoreResourceGroupName = $CdfConfig.Platform.Config.configStoreResourceGroupName
+        $configStoreName = $CdfConfig.Platform.Config.configStoreName
+        $configStoreEndpoint = $CdfConfig.Platform.Config.configStoreEndpoint
+        $templateName = $CdfConfig.Platform.Config.templateName
+        $templateVersion = $CdfConfig.Platform.Config.templateVersion
+
+        Write-Host "Saving $($Scope.ToLower()) config to $configStoreName."
+
+        $keyName = "CdfConfig-$($Scope)-$EnvKey-$($RegionDetails.code)"
+
+        if ($configStoreType.ToUpper() -eq 'APPCONFIG') {
+            $configNames = @("Config", "Env", "Tags", "Features", "NetworkConfig", "AccessControl", "ResourceNames")
+            foreach ($configName in $configNames) {
+                $jsonValue = $ScopeConfig[$configName] | ConvertTo-Json -Depth 10
+                $null = Set-AzAppConfigurationKeyValue `
+                    -Endpoint $configStoreEndpoint `
+                    -Key "$keyName-$configName" `
+                    -Label  "$templateName-$templateVersion" `
+                    -Value $jsonValue `
+                    -ContentType 'application/json'
+
+            }
+        }
+        elseif ($configStoreType.ToUpper() -eq 'KEYVAULT') {
+            $jsonValue = $ScopeConfig | ConvertTo-Json -Depth 10
+            $jsonValue = ConvertTo-SecureString -String $jsonValue -AsPlainText -Force
+            $null = Set-AzKeyVaultSecret `
+                -VaultName $configStoreName `
+                -Name $keyName `
+                -SecretValue $jsonValue `
+                -ContentType 'application/json'
+        }
+        elseif ($configStoreType.ToUpper() -eq 'STORAGEACCOUNT') {
+            $ctx = New-AzStorageContext -StorageAccountName $configStoreName -UseConnectedAccount
+            $containerName = 'cdfconfig'
+            $container = Get-AzStorageContainer -Name $containerName -Context $ctx -ErrorAction SilentlyContinue
+            if (!$container) {
+                $container = New-AzStorageContainer -Name $containerName  -Context $ctx
+            }
+            Set-AzStorageBlobContent -File $OutputConfigFilePath -Force -Container $containerName -Blob $keyName -Context $ctx
+        }
+    }
+    End {
+    }
+}


### PR DESCRIPTION
As part of this feature, configuration can be saved, in addition to deployment output, in some external storage. As of now, there are 3 storage types which can be used. These storage resources should pre-exist in some external centralized subscription. For example, these resources can be created in a subscription dedicated for management.  Same resource will be used to store configuration for all different environments (dev, tst, qa, prd etc.) 
1. App Configuration:   Due to size limitation, we can store entire config under a single key. Different types of configuration will be stored under different key. Naming convention for key is: CdfConfig-{Scope}-{EnvKey}-{Region}-{ConfigType}. A label with naming convention {templateName}-{templateVersion} is attached to every key.
2. KeyVault: All types of configuration will be stored in a single secret. Naming convention for key is: CdfConfig-{Scope}-{EnvKey}-{Region}
3. StorageAccount: All types of configuration will be stored in a a single blob under a container 'cdfconfig'. Naming convention for blob name is: CdfConfig-{Scope}-{EnvKey}-{Region}.

External storage details are provided in platform config file. Following properties required are required:
"configStoreType": "Type of resource: AppConfig or KeyVault or StorageAccount",
    "configStoreSubscriptionId": "SubscriptionId",
    "configStoreResourceGroupName": "RG name",
    "configStoreName": "resource name",
    "configStoreEndpoint": "resource endpoint"

As part of the process, once deployment is successfully completed then it will save configuration in any one the specified config store type. While retrieving config, if for any reason config is not retrieved from specified store type then it will try to fetch config from deployment output.