### PR TITLE
Keep same identier as specified in cdf-secrets file

### DIFF
--- a/CDFModule/Public/func_Get-ServiceConfigSettings.ps1
+++ b/CDFModule/Public/func_Get-ServiceConfigSettings.ps1
@@ -129,7 +129,8 @@ Function Get-ServiceConfigSettings {
                 $UpdateSettings[$appSettingKey] = $value
             }
             "Secret" {
-                $kvSecretName = "Internal-$($CdfConfig.Service.Config.serviceName)-$($setting.Identifier)"
+                #$kvSecretName = "Internal-$($CdfConfig.Service.Config.serviceName)-$($setting.Identifier)"
+                $kvSecretName = $setting.Identifier
                 if ($SecretValue) {
                     $secret = Get-AzKeyVaultSecret `
                         -DefaultProfile $azCtx `
@@ -168,7 +169,8 @@ Function Get-ServiceConfigSettings {
                 $UpdateSettings[$appSettingKey] = $value
             }
             "Secret" {
-                $kvSecretName = "External-$($CdfConfig.Service.Config.serviceName)-$($setting.Identifier)"
+                #$kvSecretName = "External-$($CdfConfig.Service.Config.serviceName)-$($setting.Identifier)"
+                $kvSecretName = $setting.Identifier
                 if ($SecretValue) {
                     $secret = Get-AzKeyVaultSecret `
                         -DefaultProfile $azCtx `


### PR DESCRIPTION
It is a temporary solution to keep same identifier as specified in cdf-secrets file