### PR TITLE
Bugfix cdf config service and connections

### DIFF
--- a/CDFModule/Public/func_Get-Config.ps1
+++ b/CDFModule/Public/func_Get-Config.ps1
@@ -1,4 +1,142 @@
-﻿Function Get-Config {
+﻿
+Function Get-Config {
+ <#
+    .SYNOPSIS
+    Get configuration for a deployed application instance for given platform instance.
+
+    .DESCRIPTION
+    Retrieves the configuration for a deployed application instance from output files stored at SourceDir for the platform instance.
+    The command will retrieve configuration for the platform, application, domain and service (if specified).
+    The command will look for configuration files in the following order:
+    1) Service cdf-config.json file (if present) for service defaults (ServiceName, ServiceGroup, ServiceType, ServiceTemplate)
+    2) Platform configuration (Get-ConfigPlatform)
+    3) Application configuration (Get-ConfigApplication)
+    4) Domain configuration (Get-ConfigDomain) (if DomainName is specified)
+    5) Service configuration (Get-ConfigService) (if ServiceName is specified)
+  
+    .PARAMETER Region
+    Azure region where the platform is deployed.
+    Defaults to value of env var CDF_REGION.
+
+    .PARAMETER PlatformId
+    Platform identifier.  
+    Defaults to value of env var CDF_PLATFORM_ID.
+    Required if env var CDF_PLATFORM_ID is not set.
+    Example: "axlint"
+
+    .PARAMETER PlatformInstance
+    Platform instance identifier.
+    Defaults to value of env var CDF_PLATFORM_INSTANCE.
+    Required if env var CDF_PLATFORM_INSTANCE is not set.
+    Example: "01"
+  
+    .PARAMETER PlatformEnvId
+    Platform environment definition identifier.
+    Defaults to value of env var CDF_PLATFORM_ENV_ID.
+    Optional. If not specified, the default environment definition for the platform instance will be used.
+    Example: "axl-tst"
+
+    .PARAMETER ApplicationId
+    Application identifier.  
+    Defaults to value of env var CDF_APPLICATION_ID.
+    Required if env var CDF_APPLICATION_ID is not set.
+    Example: "intg"
+
+    .PARAMETER ApplicationInstance
+    Application instance identifier.
+    Defaults to value of env var CDF_APPLICATION_INSTANCE.
+    Required if env var CDF_APPLICATION_INSTANCE is not set.
+    Example: "01"
+
+    .PARAMETER ApplicationEnvId
+    Application environment definition identifier.
+    Defaults to value of env var CDF_APPLICATION_ENV_ID.
+    Optional. If not specified, the default environment definition for the application instance will be used.
+    Example: "axl-uat"
+
+    .PARAMETER DomainName
+    Name of the domain to retrieve configuration for.
+    Defaults to value of env var CDF_DOMAIN_NAME.
+    Optional. If not specified, domain configuration will not be retrieved.
+    Example: "b2b"
+
+    .PARAMETER ServiceName
+    Name of the service to retrieve configuration for.
+    Defaults to cdf-config.json ServiceDefaults.ServiceName if present.
+    Or defaults to value of env var CDF_SERVICE_NAME.
+    Optional. If not specified, service configuration will not be retrieved.
+    Example: "svc01"
+
+    .PARAMETER ServiceType
+    Service type to use if service configuration is not found in a configuration file.
+    Defaults to cdf-config.json ServiceDefaults.ServiceType if present.
+    Or defaults to value of env var CDF_SERVICE_TYPE.
+    Example: "javascript" "donnet", "la-sample"
+
+    .PARAMETER ServiceGroup
+    Service group to use if service configuration is not found in a configuration file.
+    Defaults to cdf-config.json ServiceDefaults.ServiceGroup if present.
+    Or defaults to value of env var CDF_SERVICE_GROUP.
+    Example: "api", "worker", "core"
+
+    .PARAMETER ServiceTemplate
+    Service template to use if service configuration is not found in a configuration file.
+    Defaults to cdf-config.json ServiceDefaults.ServiceTemplate if present.
+    Or defaults to value of env var CDF_SERVICE_TEMPLATE.
+    Example: "logicapp-standard-v1", "containerapp-api-v1", "functionapp-api-v1"
+
+    .PARAMETER Deployed
+    Switch to indicate that only deployed configuration should be retrieved.
+    If specified, the command will return a warning if the platform, application, domain or service
+    is not marked as deployed in the configuration files.
+    Defaults to $false.
+
+    .PARAMETER ServiceSrcPath
+    Path to the service source directory. Defaults to current directory.
+
+    .PARAMETER CdfInfraTemplatePath
+    Path to the cdf-infra templates directory.
+    Defaults to "../../cdf-infra".
+
+    .PARAMETER CdfInfraSourcePath
+    Path to the cdf-infra source directory.
+    Defaults to "../../cdf-infra/src".
+
+    .PARAMETER CdfSharedPath
+    Path to the shared-infra source directory.
+    Defaults to "../../shared-infra".
+
+    .PARAMETER SharedTemplatePath
+    Path to the shared-infra templates directory.
+    Defaults to "$CdfSharedPath/templates". 
+
+    .INPUTS
+    None.
+
+    .OUTPUTS
+    CdfConfiguration
+
+    .EXAMPLE
+    Get-CdfConfig -Deployed
+
+    .EXAMPLE
+    $config = Get-Config `
+        -Region "northeurope" `
+        -PlatformId "axlint" `
+        -PlatformInstance "01" `
+        -PlatformEnvId "axl-tst" `
+        -ApplicationId "intg" `
+        -ApplicationInstance "01" `
+        -ApplicationEnvId "axl-uat" `
+        -DomainName "b2b" `
+        -ServiceName "svc01" `
+        -Deployed
+
+    .LINK
+    Show-CdfConfig
+
+    #>
+
   [CmdletBinding()]
   Param(
 
@@ -151,6 +289,7 @@
       $config = Get-ConfigService `
         -CdfConfig $config `
         -ServiceName $ServiceName `
+        -ServiceSrcPath $ServiceSrcPath `
         -SourceDir $CdfInfraSourcePath `
         -WarningAction:Continue `
         -Deployed -ErrorAction Stop

--- a/CDFModule/Public/func_Get-ConfigService.ps1
+++ b/CDFModule/Public/func_Get-ConfigService.ps1
@@ -12,6 +12,9 @@
     .PARAMETER ServiceName
     Name of the service
 
+    .PARAMETER ServiceSrcPath
+    Path to the service source directory. Defaults to current directory.
+
     .PARAMETER SourceDir
     Path to the platform source directory. Defaults to "./src".
 
@@ -48,6 +51,8 @@
     [Parameter(Mandatory = $false)]
     [string] $ServiceName = $env:CDF_SERVICE_NAME,
     [Parameter(Mandatory = $false)]
+    [string] $ServiceSrcPath = ".",
+    [Parameter(Mandatory = $false)]
     [switch] $Deployed,
     [Parameter(Mandatory = $false)]
     [string] $SourceDir = $env:CDF_INFRA_SOURCE_PATH ?? './src'
@@ -78,29 +83,38 @@
       Write-Verbose "Loading configuration file"
       $CdfService = Get-Content "$sourcePath/service/service.$platformEnvKey-$applicationEnvKey-$DomainName-$ServiceName-$regionCode.json" | ConvertFrom-Json -AsHashtable
     }
-    if (Test-Path "cdf-config.json" ) {
+
+
+    $cdfConfigFile = Join-Path -Path $ServiceSrcPath  -ChildPath 'cdf-config.json'
+    if (Test-Path $cdfConfigFile) {
       Write-Verbose "Loading cdf-config.json file"
-      $serviceConfig = Get-Content "cdf-config.json" | ConvertFrom-Json -AsHashtable
+      $cdfSchemaPath = Join-Path -Path $MyInvocation.MyCommand.Module.ModuleBase -ChildPath 'Resources/Schemas/cdf-service-config.schema.json'
+      if (!(Test-Json -SchemaFile $cdfSchemaPath -Path $cdfConfigFile)) {
+        Write-Error "Service configuration file did not validate. Please check errors above and correct."
+        Write-Error "File path:  $cdfConfigFile"
+        return
+      }
+      $serviceConfig = Get-Content $cdfConfigFile | ConvertFrom-Json -AsHashtable
       $CdfService = [ordered] @{
-        IsDeployed = $false
-        Env        = [ordered] @{}
-        Config     = [ordered] @{
+        IsDeployed   = $false
+        Env          = [ordered] @{}
+        Config       = [ordered] @{
           serviceName     = $serviceConfig.ServiceDefaults.ServiceName
           serviceType     = $serviceConfig.ServiceDefaults.ServiceType
           serviceGroup    = $serviceConfig.ServiceDefaults.ServiceGroup
           serviceTemplate = $serviceConfig.ServiceDefaults.ServiceTemplate
         }
-        Features   = [ordered] @{}
+        Features     = [ordered] @{}
         ConfigSource = "FILE"
       }
     }
     else {
       Write-Verbose "No service configuration file found '$ServiceName' with platform key '$platformEnvKey', application key '$applicationEnvKey', domain name '$DomainName' and region code '$regionCode'."
       $CdfService = [ordered] @{
-        IsDeployed = $false
-        Env        = [ordered] @{}
-        Config     = [ordered] @{}
-        Features   = [ordered] @{}
+        IsDeployed   = $false
+        Env          = [ordered] @{}
+        Config       = [ordered] @{}
+        Features     = [ordered] @{}
         ConfigSource = "NO-SOURCE"
       }
     }
@@ -108,72 +122,72 @@
     if ($Deployed) {
       if ($CdfConfig.Platform.Config.configStoreType) {
         $regionDetails = [ordered] @{
-            region = $region
-            code   = $regionCode
-            name   = $regionName
+          region = $region
+          code   = $regionCode
+          name   = $regionName
         }
         $cdfConfigOutput = Get-ConfigFromStore `
-            -CdfConfig $CdfConfig `
-            -Scope 'Service' `
-            -EnvKey "$platformEnvKey-$applicationEnvKey-$DomainName-$ServiceName" `
-            -RegionDetails $regionDetails `
-            -ErrorAction Continue
-    }
-    if ($cdfConfigOutput -eq $null -or ($cdfConfigOutput -ne $null -and $cdfConfigOutput.Count -eq 0)) {
-
-      # Get latest deployment result outputs
-      $deploymentName = "service-$platformEnvKey-$applicationEnvKey-$($CdfConfig.Domain.Config.domainName)-$ServiceName-$regionCode"
-
-      $azCtx = Get-AzureContext -SubscriptionId $CdfConfig.Platform.Env.subscriptionId
-      Write-Verbose "Fetching deployment of '$deploymentName' at '$region' using resourceGroup [$($CdfConfig.Domain.ResourceNames.domainResourceGroupName)] for runtime environment '$($applicationEnv.name)'."
-
-      $result = Get-AzResourceGroupDeployment  `
-        -DefaultProfile $azCtx `
-        -Name "$deploymentName" `
-        -ResourceGroupName $CdfConfig.Domain.ResourceNames.domainResourceGroupName `
-        -ErrorAction SilentlyContinue
-
-      While ($result -and -not($result.ProvisioningState -eq 'Succeeded' -or $result.ProvisioningState -eq 'Failed' -or $result.ProvisioningState -eq 'Cancelled')) {
-        Write-Host 'Deployment still running...'
-        Start-Sleep 30
-        $result = Get-AzSubscriptionDeployment -DefaultProfile $azCtx -Name "$deploymentName"
-        Write-Verbose $result
+          -CdfConfig $CdfConfig `
+          -Scope 'Service' `
+          -EnvKey "$platformEnvKey-$applicationEnvKey-$DomainName-$ServiceName" `
+          -RegionDetails $regionDetails `
+          -ErrorAction Continue
       }
+      if ($cdfConfigOutput -eq $null -or ($cdfConfigOutput -ne $null -and $cdfConfigOutput.Count -eq 0)) {
 
-      if ($result -and $result.ProvisioningState -eq "Succeeded") {
-        # Setup domain definitions
-        $CdfService = [ordered] @{
-          IsDeployed    = $true
-          Tags          = $result.Outputs.serviceTags.Value
-          Config        = $result.Outputs.serviceConfig.Value
-          Features      = $result.Outputs.serviceFeatures.Value
-          ResourceNames = $result.Outputs.serviceResourceNames.Value
-          NetworkConfig = $result.Outputs.serviceNetworkConfig.Value
-          AccessControl = $result.Outputs.serviceAccessControl.Value
-          ConfigSource = 'DEPLOYMENTOUTPUT'
+        # Get latest deployment result outputs
+        $deploymentName = "service-$platformEnvKey-$applicationEnvKey-$($CdfConfig.Domain.Config.domainName)-$ServiceName-$regionCode"
+
+        $azCtx = Get-AzureContext -SubscriptionId $CdfConfig.Platform.Env.subscriptionId
+        Write-Verbose "Fetching deployment of '$deploymentName' at '$region' using resourceGroup [$($CdfConfig.Domain.ResourceNames.domainResourceGroupName)] for runtime environment '$($applicationEnv.name)'."
+
+        $result = Get-AzResourceGroupDeployment  `
+          -DefaultProfile $azCtx `
+          -Name "$deploymentName" `
+          -ResourceGroupName $CdfConfig.Domain.ResourceNames.domainResourceGroupName `
+          -ErrorAction SilentlyContinue
+
+        While ($result -and -not($result.ProvisioningState -eq 'Succeeded' -or $result.ProvisioningState -eq 'Failed' -or $result.ProvisioningState -eq 'Cancelled')) {
+          Write-Host 'Deployment still running...'
+          Start-Sleep 30
+          $result = Get-AzSubscriptionDeployment -DefaultProfile $azCtx -Name "$deploymentName"
+          Write-Verbose $result
         }
 
-        # Convert to normalized hashtable
-        $CdfService = $CdfService | ConvertTo-Json -depth 10 | ConvertFrom-Json -AsHashtable
-      }
-      elseif ($result -and ($result.ProvisioningState -eq "Failed" -or $result.ProvisioningState -eq "Cancelled")) {
-        Write-Warning "Deployment in invalid state [$($result.ProvisioningState)] for '$deploymentName' at '$region' using subscription [$($azCtx.Subscription.Name)] for runtime environment '$($applicationEnv.name)'."
-        Write-Warning "Returning configuration from file, if available."
-      }
-      else {
-        Write-Warning "No deployment found for '$deploymentName' at '$region' using subscription [$($azCtx.Subscription.Name)] for runtime environment '$($applicationEnv.name)'."
-        if (Test-Path "cdf-config.json") {
-          Write-Warning "Using service defaults in cdf-config.json ."
+        if ($result -and $result.ProvisioningState -eq "Succeeded") {
+          # Setup domain definitions
+          $CdfService = [ordered] @{
+            IsDeployed    = $true
+            Tags          = $result.Outputs.serviceTags.Value
+            Config        = $result.Outputs.serviceConfig.Value
+            Features      = $result.Outputs.serviceFeatures.Value
+            ResourceNames = $result.Outputs.serviceResourceNames.Value
+            NetworkConfig = $result.Outputs.serviceNetworkConfig.Value
+            AccessControl = $result.Outputs.serviceAccessControl.Value
+            ConfigSource  = 'DEPLOYMENTOUTPUT'
+          }
+
+          # Convert to normalized hashtable
+          $CdfService = $CdfService | ConvertTo-Json -depth 10 | ConvertFrom-Json -AsHashtable
+        }
+        elseif ($result -and ($result.ProvisioningState -eq "Failed" -or $result.ProvisioningState -eq "Cancelled")) {
+          Write-Warning "Deployment in invalid state [$($result.ProvisioningState)] for '$deploymentName' at '$region' using subscription [$($azCtx.Subscription.Name)] for runtime environment '$($applicationEnv.name)'."
+          Write-Warning "Returning configuration from file, if available."
         }
         else {
-          Write-Warning "Returning service configuration from file, if available."
+          Write-Warning "No deployment found for '$deploymentName' at '$region' using subscription [$($azCtx.Subscription.Name)] for runtime environment '$($applicationEnv.name)'."
+          if (Test-Path "cdf-config.json") {
+            Write-Warning "Using service defaults in cdf-config.json ."
+          }
+          else {
+            Write-Warning "Returning service configuration from file, if available."
+          }
         }
       }
-    }
-    else{
-      $cdfConfigOutput.Add("ConfigSource",$CdfConfig.Platform.Config.configStoreType.ToUpper())
-      $CdfService = $cdfConfigOutput
-    }
+      else {
+        $cdfConfigOutput.Add("ConfigSource", $CdfConfig.Platform.Config.configStoreType.ToUpper())
+        $CdfService = $cdfConfigOutput
+      }
     }
     else {
       if ($CdfService.IsDeployed) {

--- a/CDFModule/Public/func_Get-ConnectionDefinitions.ps1
+++ b/CDFModule/Public/func_Get-ConnectionDefinitions.ps1
@@ -11,7 +11,11 @@
 
     # Fetch all deployed API Connections and build a hashtable of connection definitions
     $connectionDefinitions = @{}
-    Get-AzResourceGroupDeployment  -ResourceGroupName $CdfConfig.Platform.ResourceNames.apiConnResourceGroupName `
+
+    $azCtx = Get-AzureContext -SubscriptionId $CdfConfig.Platform.Env.subscriptionId
+    Get-AzResourceGroupDeployment `
+        -DefaultProfile $azCtx `
+        -ResourceGroupName $CdfConfig.Platform.ResourceNames.apiConnResourceGroupName `
     | Where-Object {
         $_.DeploymentName -like "$platformKey-connection-*" -or `
             $_.DeploymentName -like "$applicationKey-connection-*" -or `


### PR DESCRIPTION
This PR fixes two bugs associated with deployment of Services.
 - The Get-CdfConfig command parameter ServiceSrcPath is not used/enforced by Get-CdfConfigService
 - The Get-CdfConnectionDefinition command does not execute azure commands with the right azure context and may fail

These two issues have been corrected.

Also, some intial cmdlet documentation was provided for Get-CdfConfig.