### PR TITLE
Adding option to export arm params file

### DIFF
--- a/CDFModule/Public/func_Deploy-TemplateApplication.ps1
+++ b/CDFModule/Public/func_Deploy-TemplateApplication.ps1
@@ -12,6 +12,9 @@
         .PARAMETER Deployed
         Override check on configuration 'IsDeployed' to force deployment of deployed configuration
 
+        .PARAMETER ExportParametersPath
+        Export the ARM parameters to given path instead of deploying the template.
+
         .PARAMETER TemplateDir
         Path to the platform template root dir. Defaults to ".".
 
@@ -45,6 +48,8 @@
         [Object]$CdfConfig,
         [Parameter(Mandatory = $false)]
         [switch] $Deployed,
+        [Parameter(Mandatory = $false)]
+        [string] $ExportParametersPath,
         [Parameter(Mandatory = $false)]
         [string] $TemplateDir = $env:CDF_INFRA_TEMPLATES_PATH ?? '.',
         [Parameter(Mandatory = $false)]
@@ -102,7 +107,25 @@
         $templateParams.applicationTags.BuildBranch = $env:GITHUB_REF_NAME ?? $env:BUILD_SOURCEBRANCH ?? $(git -C $TemplateDir branch --show-current)
         $templateParams.applicationTags.BuildRepo = $env:GITHUB_REPOSITORY ?? $env:BUILD_REPOSITORY_NAME ?? $(Split-Path -Leaf (git -C $TemplateDir remote get-url origin))
 
-        Write-Debug "Template parameters: $($templateParams | ConvertTo-Json -Depth 10 | Out-String)"
+        if ($ExportParametersPath) {
+            $deploymentParams = [ordered] @{
+                'schema'        = "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#"
+                'contenVersion' = "1.0.0.0"
+                'parameters'    = [ordered] @{
+                }
+            }
+            $templateParams.Keys | ForEach-Object {
+                $deploymentParams.parameters[$_] = @{
+                    value = $templateParams[$_]
+                }
+            }
+            $deploymentParams | ConvertTo-Json -Depth 10 | Out-File -FilePath $ExportParametersPath -Force
+            Write-Host "Exported domain parameters to $ExportParametersPath"
+            return;
+        }
+        else {
+            Write-Debug "Template parameters: $($templateParams | ConvertTo-Json -Depth 10 | Out-String)"
+        }
 
         $azCtx = Get-AzureContext -SubscriptionId $CdfConfig.Platform.Env.subscriptionId
 

--- a/CDFModule/Public/func_Deploy-TemplateDomain.ps1
+++ b/CDFModule/Public/func_Deploy-TemplateDomain.ps1
@@ -13,6 +13,9 @@ Function Deploy-TemplateDomain {
         .PARAMETER Deployed
         Override check on configuration 'IsDeployed' to force deployment of deployed configuration
 
+        .PARAMETER ExportParametersPath
+        Export the ARM parameters to given path instead of deploying the template.
+
         .PARAMETER TemplateDir
         Path to the platform template root dir. Defaults to ".".
 

--- a/CDFModule/Public/func_Deploy-TemplatePlatform.ps1
+++ b/CDFModule/Public/func_Deploy-TemplatePlatform.ps1
@@ -12,6 +12,9 @@
     .PARAMETER Deployed
     Override check on configuration 'IsDeployed' to force deployment of deployed configuration
 
+    .PARAMETER ExportParametersPath
+    Export the ARM parameters to given path instead of deploying the template.
+
     .PARAMETER TemplateDir
     Path to the platform template root dir. Defaults to ".".
 
@@ -115,12 +118,12 @@
             $deploymentParams = [ordered] @{
                 'schema'        = "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#"
                 'contenVersion' = "1.0.0.0"
-                'parameters' = [ordered] @{
+                'parameters'    = [ordered] @{
                 }
             }
             $templateParams.Keys | ForEach-Object {
                 $deploymentParams.parameters[$_] = @{
-                        value = $templateParams[$_]
+                    value = $templateParams[$_]
                 }
             }
             $deploymentParams | ConvertTo-Json -Depth 10 | Out-File -FilePath $ExportParametersPath -Force

--- a/CDFModule/Public/func_Deploy-TemplateService.ps1
+++ b/CDFModule/Public/func_Deploy-TemplateService.ps1
@@ -9,6 +9,9 @@
         .PARAMETER CdfConfig
         The CDFConfig object that holds the current scope configurations (Platform, Application and Domain)
 
+        .PARAMETER ExportParametersPath
+        Export the ARM parameters to given path instead of deploying the template.
+
         .PARAMETER TemplateDir
         Path to the platform template root dir. Defaults to ".".
 


### PR DESCRIPTION
This PR adds option to export ARM parameters file for the template deployments:

`Get-CdfConfigPlatform | Deploy-CdfTemplatePlatform -ExportParametersPath my.platform.params.json`


It allows for visually examine parameters, store parameters for reference or even replace CDFModule for IaC deployments and revert to classic template file and template parameter files deployment.
