### PR TITLE
Fix container apps env vars with both SecretRef and Value properties

### DIFF
--- a/CDFModule/Public/func_Deploy-ServiceContainerApp.ps1
+++ b/CDFModule/Public/func_Deploy-ServiceContainerApp.ps1
@@ -154,6 +154,7 @@
                         -SecretRef $secret.Name.ToLower()
                 }
                 else {
+                    $envVar.Value = $null
                     $envVar.SecretRef = $secret.Name.ToLower()
                 }
             }
@@ -244,10 +245,19 @@ Function Set-EnvVarValue {
     Write-Host "Adding container app env setting: $VarName"
     $envVar = $Settings | Where-Object { $_.Name -eq $VarName }
     if ($null -eq $envVar) {
+        Write-Host "Creating new container app env setting: $VarName"
         $Settings += New-AzContainerAppEnvironmentVarObject -Name $VarName -Value $VarValue
     }
     else {
-        $envVar.Value = $VarValue
+        if ($null -ne $envVar.SecretRef ) {
+            Write-Verbose " - Skipping update of secret ref for env var: $VarName"
+        }
+        elseif ($null -ne $envVar.Value ) {
+            $envVar.Value = $VarValue
+        }
+        else {
+            Write-Warning " - Inconsistency, missing both Value and SecretRef for env var: $VarName"
+        }
     }
     return $Settings
 }


### PR DESCRIPTION
This PR fixes a bug in container app when assigning secret env vars. 

The current implementation assigns Value for all env vars and then a SecretRef for secrets. Both properties are deployed in Azure and returned when fetching configuration. When redeploying a service which has manually entered secrets or secrets deployed in template  without the Value field the Deploy-CdfServiceContainerApp command will fail on the null Value fields.