### PR TITLE
feat: Allow partial service configuration without requiring all parameters

### DIFF
--- a/CDFModule/Public/func_Get-Config.ps1
+++ b/CDFModule/Public/func_Get-Config.ps1
@@ -285,17 +285,20 @@ Function Get-Config {
       # Continue Domain configuration
     }
 
-    if ($ServiceName -and $Deployed -and $config.Domain.IsDeployed) {
+    if ($ServiceName -and $config.Domain.IsDeployed) {
+      $serviceParams = @{}
+      if ($ServiceName) { $serviceParams['ServiceName'] = $ServiceName }
+      if ($ServiceType) { $serviceParams['ServiceType'] = $ServiceType }
+      if ($ServiceTemplate) { $serviceParams['ServiceTemplate'] = $ServiceTemplate }
+      if ($ServiceGroup) { $serviceParams['ServiceGroup'] = $ServiceGroup }
+
       $config = Get-ConfigService `
         -CdfConfig $config `
-        -ServiceName $ServiceName `
-        -ServiceType $ServiceType `
-        -ServiceTemplate $ServiceTemplate `
-        -ServiceGroup $ServiceGroup `
+        @serviceParams `
         -ServiceSrcPath $ServiceSrcPath `
         -SourceDir $CdfInfraSourcePath `
         -WarningAction:Continue `
-        -Deployed -ErrorAction Stop
+        -Deployed:$Deployed -ErrorAction Stop
     }
   }
   return $config

--- a/CDFModule/Public/func_Get-ConfigService.ps1
+++ b/CDFModule/Public/func_Get-ConfigService.ps1
@@ -202,11 +202,11 @@ Function Get-InfraServiceConfig {
   Param(
     [Parameter(Mandatory = $true)]
     [string] $ServiceName,
-    [Parameter(Mandatory = $true)]
+    [Parameter(Mandatory = $false)]
     [string] $ServiceType,
-    [Parameter(Mandatory = $true)]
+    [Parameter(Mandatory = $false)]
     [string] $ServiceGroup,
-    [Parameter(Mandatory = $true)]
+    [Parameter(Mandatory = $false)]
     [string] $ServiceTemplate,
     [Parameter(Mandatory = $true)]
     [string] $ServiceConfigPath


### PR DESCRIPTION
Fixes #49

- Makes `ServiceType`, `ServiceGroup`, `ServiceTemplate` optional in `Get-InfraServiceConfig`
- Uses splatting in `Get-Config` to pass only bound parameters to `Get-ConfigService`
- Passes `-Deployed:$Deployed` explicitly instead of using it as a gate condition

This enables loading service config in local/dev scenarios where not all parameters are known upfront.