### PR TITLE
feat: CDF package registry and dependency management

### DIFF
--- a/CDFModule/Private/func_CdfPackageCache.ps1
+++ b/CDFModule/Private/func_CdfPackageCache.ps1
@@ -1,0 +1,236 @@
+# Local cache management for CDF packages
+# Cache layout: ~/.cdf/packages/{templates|configs}/<endpoint>/<path>/<release>/
+
+Function Get-CdfPackageCacheRoot {
+    [CmdletBinding()]
+    Param()
+
+    $CDF_USER_HOME = $env:APPDATA ?? $env:HOME
+    $cachePath = Join-Path -Path $CDF_USER_HOME -ChildPath '.cdf/packages'
+    return $cachePath
+}
+
+Function Get-CdfPackageCachePath {
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory = $true)]
+        [ValidateSet('templates', 'configs')]
+        [string]$PackageType,
+        [Parameter(Mandatory = $true)]
+        [string]$Endpoint,
+        [Parameter(Mandatory = $true)]
+        [string]$PackagePath,
+        [Parameter(Mandatory = $true)]
+        [string]$Release
+    )
+
+    $cacheRoot = Get-CdfPackageCacheRoot
+    return Join-Path -Path $cacheRoot -ChildPath "$PackageType/$Endpoint/$PackagePath/$Release"
+}
+
+Function Get-CdfCachedPackage {
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory = $true)]
+        [ValidateSet('templates', 'configs')]
+        [string]$PackageType,
+        [Parameter(Mandatory = $true)]
+        [string]$Endpoint,
+        [Parameter(Mandatory = $true)]
+        [string]$PackagePath,
+        [Parameter(Mandatory = $true)]
+        [string]$Release
+    )
+
+    $cachePath = Get-CdfPackageCachePath -PackageType $PackageType -Endpoint $Endpoint -PackagePath $PackagePath -Release $Release
+    if (Test-Path $cachePath) {
+        return @{
+            Path    = $cachePath
+            Cached  = $true
+            Release = $Release
+        }
+    }
+    return @{
+        Path    = $cachePath
+        Cached  = $false
+        Release = $Release
+    }
+}
+
+Function Save-CdfPackageToCache {
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory = $true)]
+        [ValidateSet('templates', 'configs')]
+        [string]$PackageType,
+        [Parameter(Mandatory = $true)]
+        [string]$Endpoint,
+        [Parameter(Mandatory = $true)]
+        [string]$PackagePath,
+        [Parameter(Mandatory = $true)]
+        [string]$Release,
+        [Parameter(Mandatory = $true)]
+        [CdfRegistryProvider]$Provider
+    )
+
+    $cachePath = Get-CdfPackageCachePath -PackageType $PackageType -Endpoint $Endpoint -PackagePath $PackagePath -Release $Release
+
+    if (Test-Path $cachePath) {
+        Write-Verbose "Package already cached at $cachePath"
+        return $cachePath
+    }
+
+    Write-Host "Downloading $PackageType/${PackagePath}:$Release from $Endpoint..."
+    $registryPath = "cdf/$PackageType/$PackagePath"
+    $Provider.Pull($registryPath, $Release, $cachePath)
+
+    # Update cache index
+    Update-CdfCacheIndex -PackageType $PackageType -Endpoint $Endpoint -PackagePath $PackagePath -Release $Release -CachePath $cachePath
+
+    return $cachePath
+}
+
+Function Get-CdfCacheIndex {
+    [CmdletBinding()]
+    Param()
+
+    $cacheRoot = Get-CdfPackageCacheRoot
+    $indexPath = Join-Path -Path $cacheRoot -ChildPath 'index.json'
+
+    if (Test-Path $indexPath) {
+        return Get-Content -Raw $indexPath | ConvertFrom-Json -AsHashtable
+    }
+    return @{
+        packages = @()
+    }
+}
+
+Function Update-CdfCacheIndex {
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory = $true)]
+        [string]$PackageType,
+        [Parameter(Mandatory = $true)]
+        [string]$Endpoint,
+        [Parameter(Mandatory = $true)]
+        [string]$PackagePath,
+        [Parameter(Mandatory = $true)]
+        [string]$Release,
+        [Parameter(Mandatory = $true)]
+        [string]$CachePath
+    )
+
+    $cacheRoot = Get-CdfPackageCacheRoot
+    $indexPath = Join-Path -Path $cacheRoot -ChildPath 'index.json'
+
+    $index = Get-CdfCacheIndex
+
+    # Remove existing entry for same package+release if present
+    $index.packages = @($index.packages | Where-Object {
+            -not ($_.type -eq $PackageType -and $_.endpoint -eq $Endpoint -and $_.path -eq $PackagePath -and $_.release -eq $Release)
+        })
+
+    $index.packages += @{
+        type      = $PackageType
+        endpoint  = $Endpoint
+        path      = $PackagePath
+        release   = $Release
+        cachePath = $CachePath
+        installed = (Get-Date -Format 'o')
+    }
+
+    if (!(Test-Path (Split-Path $indexPath))) {
+        New-Item -ItemType Directory -Path (Split-Path $indexPath) -Force | Out-Null
+    }
+    $index | ConvertTo-Json -Depth 5 | Out-File -FilePath $indexPath -Force
+}
+
+# Semver comparison utilities
+
+Function Test-CdfSemverMatch {
+    <#
+    .SYNOPSIS
+    Tests if a release version satisfies a semver range expression.
+    Supports: >=x.y.z, ^x.y.z, ~x.y.z, x.y.z (exact)
+    #>
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory = $true)]
+        [string]$Release,
+        [Parameter(Mandatory = $true)]
+        [string]$Range
+    )
+
+    $releaseVersion = ConvertTo-CdfSemver $Release
+    if ($null -eq $releaseVersion) { return $false }
+
+    # Exact match
+    if ($Range -match '^\d+\.\d+\.\d+') {
+        if ($Range -notmatch '^[~^><=]') {
+            $rangeVersion = ConvertTo-CdfSemver $Range
+            return ($null -ne $rangeVersion) -and ($releaseVersion -eq $rangeVersion)
+        }
+    }
+
+    # >=x.y.z
+    if ($Range -match '^>=(.+)$') {
+        $minVersion = ConvertTo-CdfSemver $Matches[1]
+        return ($null -ne $minVersion) -and ($releaseVersion -ge $minVersion)
+    }
+
+    # ^x.y.z (compatible: same major, >= minor.patch)
+    if ($Range -match '^\^(.+)$') {
+        $baseVersion = ConvertTo-CdfSemver $Matches[1]
+        if ($null -eq $baseVersion) { return $false }
+        return ($releaseVersion.Major -eq $baseVersion.Major) -and ($releaseVersion -ge $baseVersion)
+    }
+
+    # ~x.y.z (reasonably close: same major.minor, >= patch)
+    if ($Range -match '^~(.+)$') {
+        $baseVersion = ConvertTo-CdfSemver $Matches[1]
+        if ($null -eq $baseVersion) { return $false }
+        return ($releaseVersion.Major -eq $baseVersion.Major) -and ($releaseVersion.Minor -eq $baseVersion.Minor) -and ($releaseVersion -ge $baseVersion)
+    }
+
+    Write-Warning "Unsupported semver range format: '$Range'"
+    return $false
+}
+
+Function ConvertTo-CdfSemver {
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory = $true)]
+        [string]$VersionString
+    )
+
+    # Strip prerelease/build metadata for comparison
+    $cleanVersion = $VersionString -replace '-.*$', '' -replace '\+.*$', ''
+    try {
+        return [version]$cleanVersion
+    }
+    catch {
+        Write-Warning "Invalid semver: '$VersionString'"
+        return $null
+    }
+}
+
+Function Resolve-CdfBestRelease {
+    <#
+    .SYNOPSIS
+    Given a list of available releases and a semver range, returns the highest matching release.
+    #>
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory = $true)]
+        [string[]]$AvailableReleases,
+        [Parameter(Mandatory = $true)]
+        [string]$Range
+    )
+
+    $matching = $AvailableReleases | Where-Object { Test-CdfSemverMatch -Release $_ -Range $Range }
+    if (-not $matching) { return $null }
+
+    # Sort descending by version and pick the highest
+    $sorted = $matching | Sort-Object { ConvertTo-CdfSemver $_ } -Descending
+    return $sorted | Select-Object -First 1
+}

--- a/CDFModule/Private/func_CdfRegistry.ps1
+++ b/CDFModule/Private/func_CdfRegistry.ps1
@@ -1,0 +1,265 @@
+# Registry provider abstraction for CDF package management
+# Supports pluggable backends (ACR, GitHub Packages, etc.)
+
+class CdfRegistryProvider {
+    [string]$Type
+    [string]$Endpoint
+
+    CdfRegistryProvider([string]$Type, [string]$Endpoint) {
+        $this.Type = $Type
+        $this.Endpoint = $Endpoint
+    }
+
+    # List available tags/releases for a package in the registry
+    [string[]] ListReleases([string]$PackagePath) {
+        throw "ListReleases must be implemented by subclass"
+    }
+
+    # Pull a package from the registry to a local directory
+    [void] Pull([string]$PackagePath, [string]$Tag, [string]$OutputDir) {
+        throw "Pull must be implemented by subclass"
+    }
+
+    # Push a local directory as a package to the registry
+    [void] Push([string]$PackagePath, [string]$Tag, [string]$SourceDir) {
+        throw "Push must be implemented by subclass"
+    }
+
+    [void] Push([string]$PackagePath, [string]$Tag, [string]$SourceDir, [hashtable]$Annotations) {
+        throw "Push must be implemented by subclass"
+    }
+}
+
+class CdfAcrRegistryProvider : CdfRegistryProvider {
+
+    CdfAcrRegistryProvider([string]$Endpoint) : base('acr', $Endpoint) {}
+
+    [string] GetOrasRef([string]$PackagePath, [string]$Tag) {
+        return "$($this.Endpoint)/${PackagePath}:${Tag}"
+    }
+
+    # Ensure oras CLI is available and user is logged in
+    [void] EnsureOras() {
+        if (-not (Get-Command 'oras' -ErrorAction SilentlyContinue)) {
+            throw "The 'oras' CLI is required for ACR registry operations. Install from https://oras.land/docs/installation"
+        }
+    }
+
+    # Login to ACR using Azure CLI token
+    [void] Login() {
+        $this.EnsureOras()
+        $token = (Get-AzAccessToken -ResourceUrl "https://$($this.Endpoint)" -ErrorAction Stop).Token
+        oras login $this.Endpoint --username '00000000-0000-0000-0000-000000000000' --password $token 2>&1 | Out-Null
+        if ($LASTEXITCODE -ne 0) {
+            throw "Failed to login to ACR '$($this.Endpoint)'"
+        }
+    }
+
+    [string[]] ListReleases([string]$PackagePath) {
+        $this.EnsureOras()
+        $ref = "$($this.Endpoint)/${PackagePath}"
+        $output = oras repo tags $ref 2>&1
+        if ($LASTEXITCODE -ne 0) {
+            Write-Warning "Failed to list tags for '$ref': $output"
+            return @()
+        }
+        return ($output -split "`n" | Where-Object { $_ -match '^\d+\.\d+\.\d+' })
+    }
+
+    [void] Pull([string]$PackagePath, [string]$Tag, [string]$OutputDir) {
+        $this.EnsureOras()
+        $ref = $this.GetOrasRef($PackagePath, $Tag)
+        if (!(Test-Path $OutputDir)) {
+            New-Item -ItemType Directory -Path $OutputDir -Force | Out-Null
+        }
+        Push-Location $OutputDir
+        try {
+            $output = oras pull $ref 2>&1
+            if ($LASTEXITCODE -ne 0) {
+                throw "Failed to pull '$ref': $output"
+            }
+        }
+        finally {
+            Pop-Location
+        }
+    }
+
+    [void] Push([string]$PackagePath, [string]$Tag, [string]$SourceDir) {
+        $this.Push($PackagePath, $Tag, $SourceDir, @{})
+    }
+
+    [void] Push([string]$PackagePath, [string]$Tag, [string]$SourceDir, [hashtable]$Annotations) {
+        $this.EnsureOras()
+        $ref = $this.GetOrasRef($PackagePath, $Tag)
+        Push-Location $SourceDir
+        try {
+            $files = Get-ChildItem -Recurse -File | ForEach-Object {
+                $_.FullName.Substring($SourceDir.Length + 1)
+            }
+            $annotationArgs = @()
+            foreach ($key in $Annotations.Keys) {
+                $annotationArgs += '--annotation'
+                $annotationArgs += "${key}=$($Annotations[$key])"
+            }
+            $output = oras push $ref @files @annotationArgs 2>&1
+            if ($LASTEXITCODE -ne 0) {
+                throw "Failed to push '$ref': $output"
+            }
+        }
+        finally {
+            Pop-Location
+        }
+    }
+}
+
+class CdfOciRegistryProvider : CdfRegistryProvider {
+    [string]$Username
+    [string]$PasswordEnvVar
+
+    CdfOciRegistryProvider([string]$Endpoint, [string]$Username, [string]$PasswordEnvVar) : base('oci', $Endpoint) {
+        $this.Username = $Username
+        $this.PasswordEnvVar = $PasswordEnvVar
+    }
+
+    [string] GetOrasRef([string]$PackagePath, [string]$Tag) {
+        return "$($this.Endpoint)/${PackagePath}:${Tag}"
+    }
+
+    [void] EnsureOras() {
+        if (-not (Get-Command 'oras' -ErrorAction SilentlyContinue)) {
+            throw "The 'oras' CLI is required for OCI registry operations. Install from https://oras.land/docs/installation"
+        }
+    }
+
+    # Login using username + password from environment variable
+    [void] Login() {
+        $this.EnsureOras()
+        $password = [System.Environment]::GetEnvironmentVariable($this.PasswordEnvVar)
+        if ([string]::IsNullOrEmpty($password)) {
+            throw "Environment variable '$($this.PasswordEnvVar)' is not set. Set it to your registry token/password."
+        }
+        # oras login requires just the registry host, not the full path
+        $registryHost = ($this.Endpoint -split '/')[0]
+        $output = oras login $registryHost --username $this.Username --password $password 2>&1
+        if ($LASTEXITCODE -ne 0) {
+            throw "Failed to login to OCI registry '$registryHost': $output"
+        }
+    }
+
+    [string[]] ListReleases([string]$PackagePath) {
+        $this.EnsureOras()
+        $ref = "$($this.Endpoint)/${PackagePath}"
+        $output = oras repo tags $ref 2>&1
+        if ($LASTEXITCODE -ne 0) {
+            Write-Warning "Failed to list tags for '$ref': $output"
+            return @()
+        }
+        return ($output -split "`n" | Where-Object { $_ -match '^\d+\.\d+\.\d+' })
+    }
+
+    [void] Pull([string]$PackagePath, [string]$Tag, [string]$OutputDir) {
+        $this.EnsureOras()
+        $ref = $this.GetOrasRef($PackagePath, $Tag)
+        if (!(Test-Path $OutputDir)) {
+            New-Item -ItemType Directory -Path $OutputDir -Force | Out-Null
+        }
+        Push-Location $OutputDir
+        try {
+            $output = oras pull $ref 2>&1
+            if ($LASTEXITCODE -ne 0) {
+                throw "Failed to pull '$ref': $output"
+            }
+        }
+        finally {
+            Pop-Location
+        }
+    }
+
+    [void] Push([string]$PackagePath, [string]$Tag, [string]$SourceDir) {
+        $this.Push($PackagePath, $Tag, $SourceDir, @{})
+    }
+
+    [void] Push([string]$PackagePath, [string]$Tag, [string]$SourceDir, [hashtable]$Annotations) {
+        $this.EnsureOras()
+        $ref = $this.GetOrasRef($PackagePath, $Tag)
+        Push-Location $SourceDir
+        try {
+            $files = Get-ChildItem -Recurse -File | ForEach-Object {
+                $_.FullName.Substring($SourceDir.Length + 1)
+            }
+            $annotationArgs = @()
+            foreach ($key in $Annotations.Keys) {
+                $annotationArgs += '--annotation'
+                $annotationArgs += "${key}=$($Annotations[$key])"
+            }
+            $output = oras push $ref @files @annotationArgs 2>&1
+            if ($LASTEXITCODE -ne 0) {
+                throw "Failed to push '$ref': $output"
+            }
+        }
+        finally {
+            Pop-Location
+        }
+    }
+}
+
+# Factory function to create a registry provider from a registry config entry
+Function New-CdfRegistryProvider {
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory = $true)]
+        [hashtable]$RegistryConfig
+    )
+
+    switch ($RegistryConfig.type) {
+        'acr' {
+            return [CdfAcrRegistryProvider]::new($RegistryConfig.endpoint)
+        }
+        'oci' {
+            $username = $RegistryConfig.username ?? 'cdf'
+            $passwordEnvVar = $RegistryConfig.passwordEnvVar ?? 'CDF_REGISTRY_TOKEN'
+            return [CdfOciRegistryProvider]::new($RegistryConfig.endpoint, $username, $passwordEnvVar)
+        }
+        default {
+            throw "Unsupported registry type: '$($RegistryConfig.type)'. Supported types: acr, oci"
+        }
+    }
+}
+
+# Resolve a named registry config using layered lookup:
+#  1. <project>/.cdf/registries/<name>.json
+#  2. $HOME/.cdf/registries/<name>.json
+#  3. Inline registries from cdf-packages.json manifest (optional hashtable)
+Function Resolve-CdfRegistryConfig {
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory = $false)]
+        [string]$Name = 'default',
+        [Parameter(Mandatory = $false)]
+        [hashtable]$InlineRegistries,
+        [Parameter(Mandatory = $false)]
+        [string]$ProjectDir = (Get-Location).Path
+    )
+
+    # 1. Project-level
+    $projectFile = Join-Path $ProjectDir ".cdf/registries/$Name.json"
+    if (Test-Path $projectFile) {
+        Write-Verbose "Resolved registry '$Name' from project: $projectFile"
+        return Get-Content -Raw $projectFile | ConvertFrom-Json -AsHashtable
+    }
+
+    # 2. User-level
+    $userFile = Join-Path $HOME ".cdf/registries/$Name.json"
+    if (Test-Path $userFile) {
+        Write-Verbose "Resolved registry '$Name' from user: $userFile"
+        return Get-Content -Raw $userFile | ConvertFrom-Json -AsHashtable
+    }
+
+    # 3. Inline from manifest
+    if ($InlineRegistries -and $InlineRegistries.ContainsKey($Name)) {
+        Write-Verbose "Resolved registry '$Name' from inline manifest"
+        return $InlineRegistries[$Name]
+    }
+
+    throw "Registry '$Name' not found. Create '$userFile' or define it in cdf-packages.json registries."
+}

--- a/CDFModule/Public/func_Get-Package.ps1
+++ b/CDFModule/Public/func_Get-Package.ps1
@@ -1,0 +1,117 @@
+Function Get-Package {
+    <#
+    .SYNOPSIS
+    Lists available and installed CDF packages from a registry.
+
+    .DESCRIPTION
+    Queries the configured registry for available releases of a template or config package.
+    Shows installed versions alongside available versions.
+
+    .PARAMETER PackageRef
+    Package reference (e.g. 'platform/cas/v2pub' for templates, 'tsdc01' for configs).
+
+    .PARAMETER PackageType
+    Type of package: 'templates' or 'configs'.
+
+    .PARAMETER Registry
+    Registry endpoint override.
+
+    .PARAMETER ManifestPath
+    Path to cdf-packages.json for registry resolution.
+
+    .PARAMETER Installed
+    Show only locally installed/cached packages.
+
+    .EXAMPLE
+    Get-CdfPackage -PackageRef 'platform/cas/v2pub' -PackageType templates
+
+    .EXAMPLE
+    Get-CdfPackage -Installed
+
+    .LINK
+    Install-CdfPackage
+    #>
+
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory = $false)]
+        [string]$PackageRef,
+        [Parameter(Mandatory = $false)]
+        [ValidateSet('templates', 'configs')]
+        [string]$PackageType = 'templates',
+        [Parameter(Mandatory = $false)]
+        [string]$Registry,
+        [Parameter(Mandatory = $false)]
+        [string]$ManifestPath = './cdf-packages.json',
+        [Parameter(Mandatory = $false)]
+        [switch]$Installed
+    )
+
+    # Show installed packages from cache index
+    if ($Installed -or -not $PackageRef) {
+        $index = Get-CdfCacheIndex
+        if ($index.packages.Count -eq 0) {
+            Write-Host "No packages installed in cache."
+            return
+        }
+
+        $packages = $index.packages
+        if ($PackageRef) {
+            $packages = $packages | Where-Object { $_.path -like "*$PackageRef*" }
+        }
+        if ($PackageType) {
+            $packages = $packages | Where-Object { $_.type -eq $PackageType }
+        }
+
+        $packages | ForEach-Object {
+            [PSCustomObject]@{
+                Type      = $_.type
+                Package   = $_.path
+                Release   = $_.release
+                Registry  = $_.endpoint
+                Installed = $_.installed
+                CachePath = $_.cachePath
+            }
+        } | Format-Table -AutoSize
+
+        return
+    }
+
+    # Query registry for available releases
+    $inlineRegistries = $null
+    if (Test-Path $ManifestPath) {
+        $manifest = Get-Content -Raw $ManifestPath | ConvertFrom-Json -AsHashtable
+        $inlineRegistries = $manifest.registries
+    }
+    if ($Registry -and $Registry -match '\.') {
+        $regConfig = @{ type = 'acr'; endpoint = $Registry }
+    }
+    else {
+        $regName = if ($Registry) { $Registry } else { 'default' }
+        $regConfig = Resolve-CdfRegistryConfig -Name $regName -InlineRegistries $inlineRegistries
+    }
+    $provider = New-CdfRegistryProvider $regConfig
+    $provider.Login()
+    $endpoint = $provider.Endpoint
+
+    $registryPath = "cdf/$PackageType/$PackageRef"
+    $releases = $provider.ListReleases($registryPath)
+
+    if (-not $releases) {
+        Write-Host "No releases found for $PackageType/$PackageRef in $endpoint"
+        return
+    }
+
+    # Check which are cached locally
+    $results = $releases | Sort-Object { ConvertTo-CdfSemver $_ } -Descending | ForEach-Object {
+        $cached = Get-CdfCachedPackage -PackageType $PackageType -Endpoint $endpoint -PackagePath $PackageRef -Release $_
+        [PSCustomObject]@{
+            Package  = $PackageRef
+            Release  = $_
+            Cached   = $cached.Cached
+            Registry = $endpoint
+        }
+    }
+
+    $results | Format-Table -AutoSize
+}

--- a/CDFModule/Public/func_Install-Package.ps1
+++ b/CDFModule/Public/func_Install-Package.ps1
@@ -1,0 +1,300 @@
+Function Install-Package {
+    <#
+    .SYNOPSIS
+    Installs CDF template and config packages from a registry to the local cache.
+
+    .DESCRIPTION
+    Reads cdf-packages.json from the current directory (or explicit path), resolves semver ranges
+    against the registry, downloads packages to the local cache, and sets CDF_INFRA_TEMPLATES_PATH
+    and CDF_INFRA_SOURCE_PATH environment variables.
+
+    Can also install individual packages when -TemplateRef or -ConfigRef is specified.
+
+    .PARAMETER ManifestPath
+    Path to cdf-packages.json. Defaults to ./cdf-packages.json.
+
+    .PARAMETER TemplateRef
+    Install a single template by reference (e.g. 'platform/cas/v2pub:2.1.0' or 'platform/cas/v2pub:^2.0.0').
+
+    .PARAMETER ConfigRef
+    Install a single config by reference (e.g. 'tsdc01:1.3.0' or 'tsdc01:^1.0.0').
+
+    .PARAMETER Registry
+    Registry endpoint override. Required when using -TemplateRef or -ConfigRef without a manifest.
+
+    .PARAMETER Force
+    Re-download packages even if already cached.
+
+    .EXAMPLE
+    Install-CdfPackage
+    # Reads ./cdf-packages.json and installs all declared packages
+
+    .EXAMPLE
+    Install-CdfPackage -TemplateRef 'platform/cas/v2pub:^2.1.0' -Registry cdfcodex.azurecr.io
+
+    .LINK
+    Publish-CdfTemplate
+    .LINK
+    Get-CdfPackage
+    .LINK
+    Test-CdfDependency
+    #>
+
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory = $false)]
+        [string]$ManifestPath = './cdf-packages.json',
+        [Parameter(Mandatory = $false)]
+        [string]$TemplateRef,
+        [Parameter(Mandatory = $false)]
+        [string]$ConfigRef,
+        [Parameter(Mandatory = $false)]
+        [string]$Registry,
+        [Parameter(Mandatory = $false)]
+        [switch]$Force
+    )
+
+    # Single package install mode
+    if ($TemplateRef -or $ConfigRef) {
+        $inlineRegistries = $null
+        if (Test-Path $ManifestPath) {
+            $manifest = Get-Content -Raw $ManifestPath | ConvertFrom-Json -AsHashtable
+            $inlineRegistries = $manifest.registries
+        }
+        if ($Registry -and $Registry -match '\.') {
+            $regConfig = @{ type = 'acr'; endpoint = $Registry }
+        }
+        else {
+            $regName = if ($Registry) { $Registry } else { 'default' }
+            $regConfig = Resolve-CdfRegistryConfig -Name $regName -InlineRegistries $inlineRegistries
+        }
+
+        $provider = New-CdfRegistryProvider $regConfig
+        $provider.Login()
+        $endpoint = $regConfig.endpoint
+
+        if ($TemplateRef) {
+            Install-CdfSinglePackage -Ref $TemplateRef -PackageType 'templates' -Provider $provider -Endpoint $endpoint -Force:$Force
+        }
+        if ($ConfigRef) {
+            Install-CdfSinglePackage -Ref $ConfigRef -PackageType 'configs' -Provider $provider -Endpoint $endpoint -Force:$Force
+        }
+        return
+    }
+
+    # Manifest-based install
+    if (-not (Test-Path $ManifestPath)) {
+        throw "No cdf-packages.json found at '$ManifestPath'. Use -ManifestPath or create one."
+    }
+
+    $manifest = Get-Content -Raw $ManifestPath | ConvertFrom-Json -AsHashtable
+    $inlineRegistries = $manifest.registries
+    $providers = @{}
+    $defaultEndpoint = $null
+
+    # Collect all registry names referenced by packages
+    $referencedRegistries = @('default')
+    if ($manifest.templates) {
+        foreach ($key in $manifest.templates.Keys) {
+            $parsed = Split-CdfPackageRef $key
+            if ($parsed.Registry) { $referencedRegistries += $parsed.Registry }
+        }
+    }
+    if ($manifest.configs) {
+        foreach ($key in $manifest.configs.Keys) {
+            $parsed = Split-CdfPackageRef $key
+            if ($parsed.Registry) { $referencedRegistries += $parsed.Registry }
+        }
+    }
+    $referencedRegistries = $referencedRegistries | Select-Object -Unique
+
+    # Initialize registry providers via layered resolution
+    foreach ($regName in $referencedRegistries) {
+        $regConfig = Resolve-CdfRegistryConfig -Name $regName -InlineRegistries $inlineRegistries
+        $providers[$regName] = New-CdfRegistryProvider $regConfig
+        if ($regName -eq 'default') {
+            $defaultEndpoint = $regConfig.endpoint
+        }
+    }
+
+    # Login to all registries
+    foreach ($provider in $providers.Values) {
+        $provider.Login()
+    }
+
+    $installedTemplates = @()
+    $installedConfigs = @()
+
+    # Install templates
+    if ($manifest.templates) {
+        foreach ($templateKey in $manifest.templates.Keys) {
+            $range = $manifest.templates[$templateKey]
+
+            # Parse registry from key (e.g. 'platform/cas/v2pub@custx')
+            $parsed = Split-CdfPackageRef $templateKey
+            $packagePath = $parsed.Path
+            $regName = $parsed.Registry ?? 'default'
+            $provider = $providers[$regName]
+            $endpoint = $provider.Endpoint
+
+            $registryPath = "cdf/templates/$packagePath"
+            $availableReleases = $provider.ListReleases($registryPath)
+
+            if (-not $availableReleases) {
+                Write-Warning "No releases found for template '$packagePath' in registry '$endpoint'"
+                continue
+            }
+
+            $bestRelease = Resolve-CdfBestRelease -AvailableReleases $availableReleases -Range $range
+            if (-not $bestRelease) {
+                Write-Warning "No release matching '$range' found for template '$packagePath'. Available: $($availableReleases -join ', ')"
+                continue
+            }
+
+            $cached = Get-CdfCachedPackage -PackageType 'templates' -Endpoint $endpoint -PackagePath $packagePath -Release $bestRelease
+            if ($cached.Cached -and -not $Force) {
+                Write-Host "Template ${packagePath}:$bestRelease already cached."
+            }
+            else {
+                if ($Force -and $cached.Cached) {
+                    Remove-Item -Recurse -Force $cached.Path
+                }
+                Save-CdfPackageToCache -PackageType 'templates' -Endpoint $endpoint -PackagePath $packagePath -Release $bestRelease -Provider $provider
+            }
+            $installedTemplates += @{ Path = $packagePath; Release = $bestRelease; Endpoint = $endpoint }
+        }
+    }
+
+    # Install configs
+    if ($manifest.configs) {
+        foreach ($configKey in $manifest.configs.Keys) {
+            $range = $manifest.configs[$configKey]
+
+            $parsed = Split-CdfPackageRef $configKey
+            $packagePath = $parsed.Path
+            $regName = $parsed.Registry ?? 'default'
+            $provider = $providers[$regName]
+            $endpoint = $provider.Endpoint
+
+            $registryPath = "cdf/configs/$packagePath"
+            $availableReleases = $provider.ListReleases($registryPath)
+
+            if (-not $availableReleases) {
+                Write-Warning "No releases found for config '$packagePath' in registry '$endpoint'"
+                continue
+            }
+
+            $bestRelease = Resolve-CdfBestRelease -AvailableReleases $availableReleases -Range $range
+            if (-not $bestRelease) {
+                Write-Warning "No release matching '$range' found for config '$packagePath'. Available: $($availableReleases -join ', ')"
+                continue
+            }
+
+            $cached = Get-CdfCachedPackage -PackageType 'configs' -Endpoint $endpoint -PackagePath $packagePath -Release $bestRelease
+            if ($cached.Cached -and -not $Force) {
+                Write-Host "Config ${packagePath}:$bestRelease already cached."
+            }
+            else {
+                if ($Force -and $cached.Cached) {
+                    Remove-Item -Recurse -Force $cached.Path
+                }
+                Save-CdfPackageToCache -PackageType 'configs' -Endpoint $endpoint -PackagePath $packagePath -Release $bestRelease -Provider $provider
+            }
+            $installedConfigs += @{ Path = $packagePath; Release = $bestRelease; Endpoint = $endpoint }
+        }
+    }
+
+    # Set environment variables for backwards compatibility
+    if ($installedTemplates.Count -gt 0 -and $defaultEndpoint) {
+        $cacheRoot = Get-CdfPackageCacheRoot
+        $templatesPath = Join-Path $cacheRoot "templates/$defaultEndpoint"
+        $env:CDF_INFRA_TEMPLATES_PATH = $templatesPath
+        Write-Host "Set CDF_INFRA_TEMPLATES_PATH=$templatesPath"
+    }
+
+    if ($installedConfigs.Count -gt 0) {
+        $firstConfig = $installedConfigs[0]
+        $cacheRoot = Get-CdfPackageCacheRoot
+        $configPath = Join-Path $cacheRoot "configs/$($firstConfig.Endpoint)/$($firstConfig.Path)/$($firstConfig.Release)"
+        $env:CDF_INFRA_SOURCE_PATH = $configPath
+        Write-Host "Set CDF_INFRA_SOURCE_PATH=$configPath"
+    }
+
+    # Summary
+    Write-Host "`nInstalled $($installedTemplates.Count) template(s) and $($installedConfigs.Count) config(s)."
+
+    # Run dependency check
+    if ($installedTemplates.Count -gt 0) {
+        Test-Dependency -Silent:$false
+    }
+}
+
+# Helper: Parse package ref with optional @registry suffix
+Function Split-CdfPackageRef {
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory = $true)]
+        [string]$Ref
+    )
+
+    if ($Ref -match '^(.+)@([^@]+)$') {
+        return @{
+            Path     = $Matches[1]
+            Registry = $Matches[2]
+        }
+    }
+    return @{
+        Path     = $Ref
+        Registry = $null
+    }
+}
+
+# Helper: Install a single package from a ref like 'platform/cas/v2pub:^2.1.0'
+Function Install-CdfSinglePackage {
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory = $true)]
+        [string]$Ref,
+        [Parameter(Mandatory = $true)]
+        [ValidateSet('templates', 'configs')]
+        [string]$PackageType,
+        [Parameter(Mandatory = $true)]
+        [CdfRegistryProvider]$Provider,
+        [Parameter(Mandatory = $true)]
+        [string]$Endpoint,
+        [Parameter(Mandatory = $false)]
+        [switch]$Force
+    )
+
+    if ($Ref -notmatch '^(.+):(.+)$') {
+        throw "Invalid package reference '$Ref'. Expected format: '<path>:<release-or-range>'"
+    }
+    $packagePath = $Matches[1]
+    $releaseOrRange = $Matches[2]
+
+    $registryPath = "cdf/$PackageType/$packagePath"
+
+    # If exact version, use directly; otherwise resolve from registry
+    if ($releaseOrRange -match '^\d+\.\d+\.\d+') {
+        $release = $releaseOrRange
+    }
+    else {
+        $availableReleases = $Provider.ListReleases($registryPath)
+        $release = Resolve-CdfBestRelease -AvailableReleases $availableReleases -Range $releaseOrRange
+        if (-not $release) {
+            throw "No release matching '$releaseOrRange' for '$packagePath'"
+        }
+    }
+
+    $cached = Get-CdfCachedPackage -PackageType $PackageType -Endpoint $Endpoint -PackagePath $packagePath -Release $release
+    if ($cached.Cached -and -not $Force) {
+        Write-Host "$PackageType/${packagePath}:$release already cached at $($cached.Path)"
+        return
+    }
+    if ($Force -and $cached.Cached) {
+        Remove-Item -Recurse -Force $cached.Path
+    }
+
+    Save-CdfPackageToCache -PackageType $PackageType -Endpoint $Endpoint -PackagePath $packagePath -Release $release -Provider $Provider
+    Write-Host "Installed $PackageType/${packagePath}:$release"
+}

--- a/CDFModule/Public/func_Publish-Config.ps1
+++ b/CDFModule/Public/func_Publish-Config.ps1
@@ -1,0 +1,90 @@
+Function Publish-Config {
+    <#
+    .SYNOPSIS
+    Publishes a CDF config package to an OCI registry.
+
+    .DESCRIPTION
+    Packs a config instance directory into an OCI artifact and pushes it to the configured registry.
+    Requires a cdf-runtime.json manifest in the config instance directory.
+
+    .PARAMETER ConfigPath
+    Path to the config instance directory (e.g. ./src/tsdc/01). Must contain cdf-runtime.json.
+
+    .PARAMETER Registry
+    Registry endpoint (e.g. cdfcodex.azurecr.io). Overrides manifest/default.
+
+    .PARAMETER Release
+    Override the release version from the manifest. Useful for CI builds.
+
+    .EXAMPLE
+    Publish-CdfConfig -ConfigPath ./src/tsdc/01
+
+    .EXAMPLE
+    Publish-CdfConfig -ConfigPath ./src/tsdc/01 -Release 1.3.0-pre.1
+
+    .LINK
+    Install-CdfPackage
+    #>
+
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory = $true)]
+        [string]$ConfigPath,
+        [Parameter(Mandatory = $false)]
+        [string]$Registry,
+        [Parameter(Mandatory = $false)]
+        [string]$Release
+    )
+
+    $resolvedPath = Resolve-Path $ConfigPath -ErrorAction Stop
+    $manifestPath = Join-Path $resolvedPath 'cdf-runtime.json'
+
+    if (-not (Test-Path $manifestPath)) {
+        throw "No cdf-runtime.json found in '$resolvedPath'. Cannot publish without a manifest."
+    }
+
+    $manifest = Get-Content -Raw $manifestPath | ConvertFrom-Json -AsHashtable
+    $platformId = $manifest.platformId
+    $instanceId = $manifest.instanceId
+    $releaseTag = $Release ? $Release : $manifest.release
+
+    if (-not $releaseTag) {
+        throw "No release version specified. Set 'release' in cdf-runtime.json or use -Release parameter."
+    }
+
+    $configKey = "$platformId$instanceId"
+
+    # Resolve registry config (layered: project → user → inline manifest)
+    $inlineRegistries = $null
+    $pkgManifestPath = Join-Path (Get-Location) 'cdf-packages.json'
+    if (Test-Path $pkgManifestPath) {
+        $pkgManifest = Get-Content -Raw $pkgManifestPath | ConvertFrom-Json -AsHashtable
+        $inlineRegistries = $pkgManifest.registries
+    }
+    if ($Registry -and $Registry -match '\.') {
+        $regConfig = @{ type = 'acr'; endpoint = $Registry }
+    }
+    else {
+        $regName = if ($Registry) { $Registry } else { 'default' }
+        $regConfig = Resolve-CdfRegistryConfig -Name $regName -InlineRegistries $inlineRegistries
+    }
+
+    $packagePath = "cdf/configs/$configKey"
+    $provider = New-CdfRegistryProvider $regConfig
+
+    # Build OCI annotations from manifest metadata
+    $annotations = @{
+        'org.opencontainers.image.title'   = $configKey
+        'org.opencontainers.image.version' = $releaseTag
+        'cdf.config.platformId'            = $platformId
+        'cdf.config.instanceId'            = $instanceId
+    }
+    if ($manifest.description) {
+        $annotations['org.opencontainers.image.description'] = $manifest.description
+    }
+
+    Write-Host "Publishing config ${configKey}:$releaseTag to $($regConfig.endpoint)..."
+    $provider.Login()
+    $provider.Push($packagePath, $releaseTag, $resolvedPath.Path, $annotations)
+    Write-Host "Successfully published ${configKey}:$releaseTag"
+}

--- a/CDFModule/Public/func_Publish-Template.ps1
+++ b/CDFModule/Public/func_Publish-Template.ps1
@@ -1,0 +1,91 @@
+Function Publish-Template {
+    <#
+    .SYNOPSIS
+    Publishes a CDF template package to an OCI registry.
+
+    .DESCRIPTION
+    Packs a template directory into an OCI artifact and pushes it to the configured registry.
+    Requires a cdf-template.json manifest in the template directory.
+
+    .PARAMETER TemplatePath
+    Path to the template directory (e.g. ./platform/cas/v2pub). Must contain cdf-template.json.
+
+    .PARAMETER Registry
+    Registry endpoint (e.g. cdfcodex.azurecr.io). Overrides manifest/default.
+
+    .PARAMETER Release
+    Override the release version from the manifest. Useful for CI builds.
+
+    .EXAMPLE
+    Publish-CdfTemplate -TemplatePath ./platform/cas/v2pub
+
+    .EXAMPLE
+    Publish-CdfTemplate -TemplatePath ./platform/cas/v2pub -Release 2.1.0-pre.1
+
+    .LINK
+    Install-CdfPackage
+    #>
+
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory = $true)]
+        [string]$TemplatePath,
+        [Parameter(Mandatory = $false)]
+        [string]$Registry,
+        [Parameter(Mandatory = $false)]
+        [string]$Release
+    )
+
+    $resolvedPath = Resolve-Path $TemplatePath -ErrorAction Stop
+    $manifestPath = Join-Path $resolvedPath 'cdf-template.json'
+
+    if (-not (Test-Path $manifestPath)) {
+        throw "No cdf-template.json found in '$resolvedPath'. Cannot publish without a manifest."
+    }
+
+    $manifest = Get-Content -Raw $manifestPath | ConvertFrom-Json -AsHashtable
+    $scope = $manifest.scope
+    $name = $manifest.name
+    $version = $manifest.version
+    $releaseTag = $Release ? $Release : $manifest.release
+
+    if (-not $releaseTag) {
+        throw "No release version specified. Set 'release' in cdf-template.json or use -Release parameter."
+    }
+
+    # Resolve registry config (layered: project → user → inline manifest)
+    $inlineRegistries = $null
+    $pkgManifestPath = Join-Path (Get-Location) 'cdf-packages.json'
+    if (Test-Path $pkgManifestPath) {
+        $pkgManifest = Get-Content -Raw $pkgManifestPath | ConvertFrom-Json -AsHashtable
+        $inlineRegistries = $pkgManifest.registries
+    }
+    if ($Registry -and $Registry -match '\.') {
+        # Literal endpoint (e.g. ghcr.io/org or myacr.azurecr.io) — assume ACR for backwards compat
+        $regConfig = @{ type = 'acr'; endpoint = $Registry }
+    }
+    else {
+        $regName = if ($Registry) { $Registry } else { 'default' }
+        $regConfig = Resolve-CdfRegistryConfig -Name $regName -InlineRegistries $inlineRegistries
+    }
+
+    $packagePath = "cdf/templates/$scope/$name/$version"
+    $provider = New-CdfRegistryProvider $regConfig
+
+    # Build OCI annotations from manifest metadata
+    $annotations = @{
+        'org.opencontainers.image.title'   = "$scope/$name/$version"
+        'org.opencontainers.image.version' = $releaseTag
+        'cdf.template.scope'               = $scope
+        'cdf.template.name'                = $name
+        'cdf.template.variant'             = $version
+    }
+    if ($manifest.description) {
+        $annotations['org.opencontainers.image.description'] = $manifest.description
+    }
+
+    Write-Host "Publishing template $scope/$name/${version}:$releaseTag to $($regConfig.endpoint)..."
+    $provider.Login()
+    $provider.Push($packagePath, $releaseTag, $resolvedPath.Path, $annotations)
+    Write-Host "Successfully published $scope/$name/${version}:$releaseTag"
+}

--- a/CDFModule/Public/func_Test-Dependency.ps1
+++ b/CDFModule/Public/func_Test-Dependency.ps1
@@ -1,0 +1,118 @@
+Function Test-Dependency {
+    <#
+    .SYNOPSIS
+    Validates CDF template dependency compatibility across installed packages.
+
+    .DESCRIPTION
+    Reads cdf-template.json manifests from all cached templates and validates:
+    (a) All declared dependency release ranges are satisfied by installed packages
+    (b) All requiredFeatures exist in the dependency's providedFeatures
+
+    .PARAMETER CachePath
+    Override the cache root for testing. Defaults to ~/.cdf/packages.
+
+    .PARAMETER Silent
+    Suppress output for use as a sub-call. Returns $true if all checks pass.
+
+    .EXAMPLE
+    Test-CdfDependency
+
+    .EXAMPLE
+    $valid = Test-CdfDependency -Silent
+
+    .LINK
+    Install-CdfPackage
+    #>
+
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory = $false)]
+        [string]$CachePath,
+        [Parameter(Mandatory = $false)]
+        [switch]$Silent
+    )
+
+    $cacheRoot = $CachePath ? $CachePath : (Get-CdfPackageCacheRoot)
+    $templatesRoot = Join-Path $cacheRoot 'templates'
+
+    if (-not (Test-Path $templatesRoot)) {
+        if (-not $Silent) { Write-Host "No templates installed. Nothing to validate." }
+        return $true
+    }
+
+    # Discover all installed template manifests
+    $manifests = @{}
+    $manifestFiles = Get-ChildItem -Path $templatesRoot -Filter 'cdf-template.json' -Recurse
+    foreach ($file in $manifestFiles) {
+        $manifest = Get-Content -Raw $file.FullName | ConvertFrom-Json -AsHashtable
+        $key = "$($manifest.scope)/$($manifest.name)/$($manifest.version)"
+        if (-not $manifests[$key]) {
+            $manifests[$key] = @()
+        }
+        $manifests[$key] += $manifest
+    }
+
+    $warnings = @()
+    $errors = @()
+
+    foreach ($key in $manifests.Keys) {
+        foreach ($manifest in $manifests[$key]) {
+            $source = "${key}:$($manifest.release)"
+
+            if (-not $manifest.dependencies) { continue }
+
+            foreach ($depKey in $manifest.dependencies.Keys) {
+                $dep = $manifest.dependencies[$depKey]
+                $depRange = $dep.release
+                $depRequiredFeatures = $dep.requiredFeatures ?? @()
+
+                # Check if dependency is installed
+                if (-not $manifests[$depKey]) {
+                    $warnings += "[$source] Dependency '$depKey' ($depRange) is not installed."
+                    continue
+                }
+
+                # Check release compatibility
+                $depManifests = $manifests[$depKey]
+                $matchingRelease = $depManifests | Where-Object {
+                    Test-CdfSemverMatch -Release $_.release -Range $depRange
+                }
+                if (-not $matchingRelease) {
+                    $installedReleases = ($depManifests | ForEach-Object { $_.release }) -join ', '
+                    $warnings += "[$source] Dependency '$depKey' requires release '$depRange' but installed: $installedReleases"
+                }
+
+                # Check feature compatibility
+                foreach ($depManifest in $depManifests) {
+                    $providedFeatures = $depManifest.providedFeatures ?? @()
+                    foreach ($requiredFeature in $depRequiredFeatures) {
+                        if ($requiredFeature -notin $providedFeatures) {
+                            $warnings += "[$source] Requires feature '$requiredFeature' from '$depKey' but it is not in providedFeatures."
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    # Report results
+    $allPassed = ($warnings.Count -eq 0) -and ($errors.Count -eq 0)
+
+    if (-not $Silent) {
+        if ($allPassed) {
+            Write-Host "All dependency checks passed. ($($manifests.Count) template(s) validated)"
+        }
+        else {
+            Write-Host "`nDependency validation results:"
+            foreach ($w in $warnings) {
+                Write-Warning $w
+            }
+            foreach ($e in $errors) {
+                Write-Error $e
+            }
+            Write-Host "$($warnings.Count) warning(s), $($errors.Count) error(s)"
+        }
+    }
+
+    return $allPassed
+}

--- a/CDFModule/Resources/Schemas/cdf-packages.schema.json
+++ b/CDFModule/Resources/Schemas/cdf-packages.schema.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://cdf.epical.net/schemas/cdf-packages.schema.json",
+  "title": "CDF Packages Manifest",
+  "description": "Workspace manifest declaring required CDF template and config packages. The registry is the boundary.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "registries": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/$defs/registry"
+      },
+      "description": "Named registries. Optional — omit to resolve from user-level ($HOME/.cdf/registries/) or project-level (.cdf/registries/) config files. Package refs without '@<registry>' use the 'default' registry."
+    },
+    "templates": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      },
+      "description": "Template package references keyed by '<scope>/<name>/<version>' or '<scope>/<name>/<version>@<registry>'. Values are semver ranges."
+    },
+    "configs": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      },
+      "description": "Config package references keyed by '<platformId><instanceId>' or '<platformId><instanceId>@<registry>'. Values are semver ranges."
+    }
+  },
+  "$defs": {
+    "registry": {
+      "type": "object",
+      "required": ["type", "endpoint"],
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["acr", "oci"],
+          "description": "Registry provider type. 'acr' for Azure Container Registry (uses Az CLI token). 'oci' for any OCI-compatible registry such as GitHub Container Registry (uses username + token from env var)."
+        },
+        "endpoint": {
+          "type": "string",
+          "description": "Registry endpoint (e.g. 'cdfcodex.azurecr.io', 'ghcr.io/my-org')."
+        },
+        "username": {
+          "type": "string",
+          "description": "Username for OCI registry login. For GHCR use your GitHub username. Defaults to 'cdf'. Only used with type 'oci'."
+        },
+        "passwordEnvVar": {
+          "type": "string",
+          "description": "Name of the environment variable containing the registry token/password. Defaults to 'CDF_REGISTRY_TOKEN'. For GHCR use 'GITHUB_TOKEN' or 'GH_TOKEN'. Only used with type 'oci'."
+        }
+      }
+    }
+  }
+}

--- a/CDFModule/Resources/Schemas/cdf-runtime.schema.json
+++ b/CDFModule/Resources/Schemas/cdf-runtime.schema.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://cdf.epical.net/schemas/cdf-runtime.schema.json",
+  "title": "CDF Runtime Manifest",
+  "description": "Manifest for a CDF runtime configuration package. Placed at the config instance root directory (e.g. src/tsdc/01/cdf-runtime.json).",
+  "type": "object",
+  "required": ["platformId", "instanceId", "release"],
+  "additionalProperties": false,
+  "properties": {
+    "platformId": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9]*$",
+      "description": "Platform identifier (e.g. 'tsdc', 'tscx')."
+    },
+    "instanceId": {
+      "type": "string",
+      "pattern": "^[0-9]+$",
+      "description": "Instance identifier (e.g. '01', '02')."
+    },
+    "release": {
+      "type": "string",
+      "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(-[a-zA-Z0-9]+(\\.[a-zA-Z0-9]+)*)?(\\+[a-zA-Z0-9]+(\\.[a-zA-Z0-9]+)*)?$",
+      "description": "Semantic version for the release lifecycle of this config package."
+    },
+    "description": {
+      "type": "string",
+      "description": "Human-readable description of the config instance."
+    },
+    "templates": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      },
+      "description": "Template dependencies keyed by '<scope>/<name>/<version>'. Values are semver ranges (e.g. '^2.1.0')."
+    }
+  }
+}

--- a/CDFModule/Resources/Schemas/cdf-template.schema.json
+++ b/CDFModule/Resources/Schemas/cdf-template.schema.json
@@ -1,0 +1,71 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://cdf.epical.net/schemas/cdf-template.schema.json",
+  "title": "CDF Template Manifest",
+  "description": "Manifest for a CDF infrastructure template package. Placed at the template root directory (e.g. platform/cas/v2pub/cdf-template.json).",
+  "type": "object",
+  "required": ["scope", "name", "version", "release"],
+  "additionalProperties": false,
+  "properties": {
+    "scope": {
+      "type": "string",
+      "enum": ["platform", "application", "domain", "service"],
+      "description": "The CDF template scope."
+    },
+    "name": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9-]*$",
+      "description": "Template name matching the directory name (e.g. 'cas', 'intg', 'microservices')."
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^[a-z0-9][a-z0-9-]*$",
+      "description": "Template version identifier matching the directory name (e.g. 'v2pub', 'v2net'). This is the template variant/architecture, not a semver."
+    },
+    "release": {
+      "type": "string",
+      "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(-[a-zA-Z0-9]+(\\.[a-zA-Z0-9]+)*)?(\\+[a-zA-Z0-9]+(\\.[a-zA-Z0-9]+)*)?$",
+      "description": "Semantic version for the release lifecycle of this template (e.g. '2.1.0', '2.1.0-pre.1')."
+    },
+    "description": {
+      "type": "string",
+      "description": "Human-readable description of the template."
+    },
+    "providedFeatures": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "uniqueItems": true,
+      "description": "Feature flags this template can enable. Declares the capability set — actual activation is determined by the config at deploy time."
+    },
+    "dependencies": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/$defs/dependency"
+      },
+      "description": "Template dependencies keyed by '<scope>/<name>/<version>' (e.g. 'platform/cas/v2pub'). Each value specifies the required release range and features."
+    }
+  },
+  "$defs": {
+    "dependency": {
+      "type": "object",
+      "required": ["release"],
+      "additionalProperties": false,
+      "properties": {
+        "release": {
+          "type": "string",
+          "description": "Semver range for the required release (e.g. '>=2.0.0', '^2.1.0')."
+        },
+        "requiredFeatures": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "uniqueItems": true,
+          "description": "Feature flags the dependency template must provide (must be in its providedFeatures)."
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Fixes #51

Adds a package management system for CDF templates and configurations.

### New public commands
- `Get-Package` — Retrieve package metadata from the CDF registry
- `Install-Package` — Install a CDF package (template or config) from the registry
- `Publish-Config` — Publish a configuration package to the registry
- `Publish-Template` — Publish a template package to the registry
- `Test-Dependency` — Validate package dependencies are satisfied

### Supporting infrastructure
- Private helpers: `CdfPackageCache`, `CdfRegistry`
- JSON schemas: `cdf-packages`, `cdf-runtime`, `cdf-template`

This is a draft — larger feature that may need review/iteration.