### PR TITLE
fix: Guard dummy secret fallback to development environment only

### DIFF
--- a/CDFModule/Public/func_Deploy-ApimKeyVaultDomainNamedValues.ps1
+++ b/CDFModule/Public/func_Deploy-ApimKeyVaultDomainNamedValues.ps1
@@ -116,8 +116,10 @@
                     $ghVariableValue = (Get-Item "env:$($NamedValue.ghVariableName)").Value
                 }
                 else {
-                    Write-Warning "Environment variable [$($NamedValue.ghVariableName)] for GitHub Secret not set, assigning dummy value 'not-defined' for development test."
-                    $ghVariableValue = 'not-defined'
+                    if ($CdfConfig.Application.Env.purpose -eq 'development') {
+                        Write-Warning "Environment variable [$($NamedValue.ghVariableName)] for GitHub Secret not set, assigning dummy value 'not-defined' for development test."
+                        $ghVariableValue = 'not-defined'
+                    }
                 }
 
                 $CurrentSecret = Get-AzKeyVaultSecret -VaultName $CdfConfig.Application.ResourceNames.keyVaultName -Name $NamedValue.kvSecretName -AsPlainText
@@ -167,8 +169,10 @@
                     $ghSecretValue = (Get-Item "env:$($NamedValue.ghSecretName)").Value
                 }
                 else {
-                    Write-Warning "Environment variable [$($NamedValue.ghSecretName)] for GitHub Secret not set, assigning dummy value 'not-defined' for development test."
-                    $ghSecretValue = 'not-defined'
+                    if ($CdfConfig.Application.Env.purpose -eq 'development') {
+                        Write-Warning "Environment variable [$($NamedValue.ghSecretName)] for GitHub Secret not set, assigning dummy value 'not-defined' for development test."
+                        $ghSecretValue = 'not-defined'
+                    }
                 }
 
                 $CurrentSecret = Get-AzKeyVaultSecret -VaultName $CdfConfig.Application.ResourceNames.keyVaultName -Name $NamedValue.kvSecretName -AsPlainText

--- a/CDFModule/Public/func_Deploy-GitHubKeyVaultSecrets.ps1
+++ b/CDFModule/Public/func_Deploy-GitHubKeyVaultSecrets.ps1
@@ -92,8 +92,10 @@
                 $ghVariableValue = (Get-Item "env:$($NamedValue.ghVariableName)").Value
             }
             else {
-                Write-Warning "Environment variable [$($NamedValue.ghVariableName)] for GitHub Secret not set, assigning dummy value 'not-defined' for development test."
-                $ghVariableValue = 'not-defined'
+                if ($CdfConfig.Application.Env.purpose -eq 'development') {
+                    Write-Warning "Environment variable [$($NamedValue.ghVariableName)] for GitHub Secret not set, assigning dummy value 'not-defined' for development test."
+                    $ghVariableValue = 'not-defined'
+                }
             }
 
             $CurrentSecret = Get-AzKeyVaultSecret -VaultName $CdfConfig.Application.ResourceNames.keyVaultName -Name $NamedValue.kvSecretName -AsPlainText
@@ -132,8 +134,10 @@
                 $ghSecretName = (Get-Item "env:$($NamedValue.ghSecretName)").Value
             }
             else {
-                Write-Warning "Environment variable [$($NamedValue.ghSecretName)] for GitHub Secret not set, assigning dummy value 'not-defined' for development test."
-                $ghSecretName = 'not-defined'
+                if ($CdfConfig.Application.Env.purpose -eq 'development') {
+                    Write-Warning "Environment variable [$($NamedValue.ghSecretName)] for GitHub Secret not set, assigning dummy value 'not-defined' for development test."
+                    $ghSecretName = 'not-defined'
+                }
             }
 
             $CurrentSecret = Get-AzKeyVaultSecret -VaultName $CdfConfig.Application.ResourceNames.keyVaultName -Name $NamedValue.kvSecretName -AsPlainText


### PR DESCRIPTION
Fixes #59

The `'not-defined'` fallback for missing GitHub Secret environment variables now only applies when `Application.Env.purpose` is `'development'`. Previously the dummy value was assigned in **all** environments, silently masking misconfigured secrets in production.

### Changed files
- `func_Deploy-ApimKeyVaultDomainNamedValues.ps1` — 2 locations
- `func_Deploy-GitHubKeyVaultSecrets.ps1` — 2 locations