### PR TITLE
fix: Resolve Postgres connection secrets from Key Vault at deploy time

### DIFF
--- a/CDFModule/Public/func_Add-ServiceConnectionSettings.ps1
+++ b/CDFModule/Public/func_Add-ServiceConnectionSettings.ps1
@@ -162,17 +162,25 @@
                 $Settings["$($SettingName)_connectionString"] = $storageContext.ConnectionString
             }
             'postgresql' {
-                $Settings["$($SettingName)_ServerName"] = $connectionParams.databaseServerFQDN
-                $Settings["$($SettingName)_Database"] = $connectionParams.database
-                $Settings["$($SettingName)_Port"] = $connectionParams.port
+                $Settings["$($SettingName)SERVERNAME"] = $connectionParams.databaseServerFQDN
+                $Settings["$($SettingName)DATABASE"] = $connectionParams.database
+                $Settings["$($SettingName)PORT"] = if ($null -eq $connectionParams.port -or $connectionParams.port -eq '') { "5432" } else { $connectionParams.port }
                 if ($ConnectionDefinition.Scope.ToLower() -eq 'platform') {
                     $keyVaultName = $CdfConfig.Platform.ResourceNames.keyVaultName
                 }
                 else {
                     $keyVaultName = $CdfConfig.Domain.ResourceNames.keyVaultName
                 }
-                $Settings["$($SettingName)_UserName"] = "@Microsoft.KeyVault(VaultName=$keyVaultName;SecretName=$($connectionParams.userSecretName))"
-                $Settings["$($SettingName)_Password"] = "@Microsoft.KeyVault(VaultName=$keyVaultName;SecretName=$($connectionParams.passwordSecretName))"
+                $Settings["$($SettingName)USERNAME"] = Get-AzKeyVaultSecret `
+                    -DefaultProfile $azCtx `
+                    -VaultName $keyVaultName `
+                    -Name $connectionParams.userSecretName `
+                    -AsPlainText
+                $Settings["$($SettingName)PASSWORD"] = Get-AzKeyVaultSecret `
+                    -DefaultProfile $azCtx `
+                    -VaultName $keyVaultName `
+                    -Name $connectionParams.passwordSecretName `
+                    -AsPlainText
             }
             default {
                 if ($ConnectionDefinition.Scope -in @('Platform', 'Application', 'Domain')) {
@@ -270,7 +278,7 @@
                 #No support for managed identity
                 $Settings["$($SettingName)SERVERNAME"] = $connectionParams.databaseServerFQDN
                 $Settings["$($SettingName)DATABASE"] = $connectionParams.database
-                $Settings["$($SettingName)PORT"] = $connectionParams.port
+                $Settings["$($SettingName)PORT"] = if ($null -eq $connectionParams.port -or $connectionParams.port -eq '') { "5432" } else { $connectionParams.port }
                 if ($ConnectionDefinition.Scope.ToLower() -eq 'platform') {
                     $keyVaultName = $CdfConfig.Platform.ResourceNames.keyVaultName
                 }


### PR DESCRIPTION
The naming convention of "UseCS" parameter separating config between "Connection Strings" and "Managed Identity" is really misleading as they should read "Development" and "Runtime". The "UseCS" parameter is available to allow local development have access to development environment resources using API keys/Connection Strings/Env vars with actual values. The "Managed Identity" is used for runtime deployment where resource URIs including KeyVault secret URIs can be used. Some Azure services do not support managed identity and for these the connection is returned similar to the "development / UseCS" model.

Previously, Postgres connection settings for local development used Key Vault references (@Microsoft.KeyVault...) which prevented direct use of the connection parameters in e.g "Export-CdfDotEnv" allowing consuming microservices to access the psql instance.

Changes:
- Connection string mode: resolve USERNAME/PASSWORD from Key Vault at development time instead of embedding Key Vault references
- Normalize setting key names: _ServerName -> SERVERNAME, _Database -> DATABASE, _Port -> PORT, _UserName -> USERNAME, _Password -> PASSWORD
- Default port to 5432 when not specified (both CS and MI modes)
- Managed identity (Runtime) mode: keep Key Vault references but add default port

BREAKING CHANGE: Consumers expecting _ServerName/_Database/_Port key format must update to SERVERNAME/DATABASE/PORT. (Why this difference?)