### PR TITLE
fix: Add -UseCS flag to Export-DotEnv service config settings

### DIFF
--- a/CDFModule/Public/func_Export-DotEnv.ps1
+++ b/CDFModule/Public/func_Export-DotEnv.ps1
@@ -29,7 +29,7 @@ Function Export-DotEnv {
 
     Write-Verbose "Reading: $InputEnv"
     $defaultSettings = Get-CdfDotEnv $InputEnv
-    $updatedSettings = $CdfConfig | Get-CdfServiceConfigSettings -UpdateSettings $defaultSettings -SecretValue
+    $updatedSettings = $CdfConfig | Get-CdfServiceConfigSettings -UseCS -UpdateSettings $defaultSettings -SecretValue
     Write-Verbose "Writing: $InputEnv"
     $updatedSettings | ConvertTo-CdfDotEnv | Set-Content -Path $OutputEnv
 }


### PR DESCRIPTION
Export-DotEnv generates .env files for local development. Without -UseCS, Get-CdfServiceConfigSettings returns managed identity settings instead of connection string settings, causing missing connection values in the generated .env file.