### PR TITLE
feat: Add -UseEnv switch for container local development connection settings

### DIFF
--- a/CDFModule/Public/func_Add-ServiceConnectionSettings.ps1
+++ b/CDFModule/Public/func_Add-ServiceConnectionSettings.ps1
@@ -7,6 +7,12 @@
 
     .PARAMETER UseCS
     Switch indicating that connections should use connection strings instead of managed identities.
+    Produces settings with Key Vault references for secrets (suitable for Azure App Service/Logic Apps).
+
+    .PARAMETER UseEnv
+    Switch indicating that connections should produce environment variable style settings with
+    uppercase suffixes (e.g. SERVERNAME, CONNECTIONSTRING) and resolved secret values.
+    Suitable for container-based local development (.env files).
 
     .PARAMETER CdfConfig
     The Config object from the target scope (Platform, Application and Domain)
@@ -57,6 +63,8 @@
     Param(
         [Parameter(Mandatory = $false)]
         [switch] $UseCS,
+        [Parameter(Mandatory = $false)]
+        [switch] $UseEnv,
         [Parameter(Mandatory = $true)]
         [hashtable]$CdfConfig,
         [Parameter(Mandatory = $true)]
@@ -162,6 +170,64 @@
                 $Settings["$($SettingName)_connectionString"] = $storageContext.ConnectionString
             }
             'postgresql' {
+                $Settings["$($SettingName)_ServerName"] = $connectionParams.databaseServerFQDN
+                $Settings["$($SettingName)_Database"] = $connectionParams.database
+                $Settings["$($SettingName)_Port"] = if ($null -eq $connectionParams.port -or $connectionParams.port -eq '') { "5432" } else { $connectionParams.port }
+                if ($ConnectionDefinition.Scope.ToLower() -eq 'platform') {
+                    $keyVaultName = $CdfConfig.Platform.ResourceNames.keyVaultName
+                }
+                else {
+                    $keyVaultName = $CdfConfig.Domain.ResourceNames.keyVaultName
+                }
+                $Settings["$($SettingName)_UserName"] = "@Microsoft.KeyVault(VaultName=$keyVaultName;SecretName=$($connectionParams.userSecretName))"
+                $Settings["$($SettingName)_Password"] = "@Microsoft.KeyVault(VaultName=$keyVaultName;SecretName=$($connectionParams.passwordSecretName))"
+            }
+            default {
+                if ($ConnectionDefinition.Scope -in @('Platform', 'Application', 'Domain')) {
+                    Write-Warning "Unsupported service provider: $($ConnectionDefinition.ServiceProvider)"
+                }
+            }
+        }
+    }
+    elseif ($UseEnv) {
+        switch ($ConnectionDefinition.ServiceProvider.ToLower()) {
+            'keyvault' {
+                $Settings["$($SettingName)URI"] = "https://$($connectionParams.name).vault.azure.net"
+            }
+            'azureeventgridpublish' {
+                $eventGridTopic = Get-AzEventGridTopic -DefaultProfile $AzCtx `
+                    -ResourceGroupName $connectionParams.resourceGroup `
+                    -Name $connectionParams.name
+                $eventGridTopicKeys = Get-AzEventGridTopicKey $eventGridTopic
+
+                $Settings["$($SettingName)ACCESSKEY"] = $eventGridTopicKeys.Key1
+                $Settings["$($SettingName)TOPICENDPOINT"] = $eventGridTopic.Endpoint
+            }
+            'servicebus' {
+                $Settings["$($SettingName)FULLYQUALIFIEDNAMESPACE"] = "$($connectionParams.name).servicebus.windows.net"
+            }
+            'eventhubs' {
+                $Settings["$($SettingName)FULLYQUALIFIEDNAMESPACE"] = "$($connectionParams.name).servicebus.windows.net"
+            }
+            'azureblob' {
+                $Settings["$($SettingName)URI"] = "https://$($connectionParams.name).blob.core.windows.net"
+            }
+            'azurefile' {
+                $storageContext = (
+                    Get-AzStorageAccount `
+                        -DefaultProfile $AzCtx `
+                        -ResourceGroupName $connectionParams.resourceGroup `
+                        -Name $connectionParams.name
+                ).Context
+                $Settings["$($SettingName)CONNECTIONSTRING"] = $storageContext.ConnectionString
+            }
+            'azuretables' {
+                $Settings["$($SettingName)URI"] = "https://$($connectionParams.name).table.core.windows.net"
+            }
+            'azurequeues' {
+                $Settings["$($SettingName)URI"] = "https://$($connectionParams.name).queue.core.windows.net"
+            }
+            'postgresql' {
                 $Settings["$($SettingName)SERVERNAME"] = $connectionParams.databaseServerFQDN
                 $Settings["$($SettingName)DATABASE"] = $connectionParams.database
                 $Settings["$($SettingName)PORT"] = if ($null -eq $connectionParams.port -or $connectionParams.port -eq '') { "5432" } else { $connectionParams.port }
@@ -188,7 +254,6 @@
                 }
             }
         }
-
     }
     else {
         # Using managed identity

--- a/CDFModule/Public/func_Export-DotEnv.ps1
+++ b/CDFModule/Public/func_Export-DotEnv.ps1
@@ -29,7 +29,7 @@ Function Export-DotEnv {
 
     Write-Verbose "Reading: $InputEnv"
     $defaultSettings = Get-CdfDotEnv $InputEnv
-    $updatedSettings = $CdfConfig | Get-CdfServiceConfigSettings -UseCS -UpdateSettings $defaultSettings -SecretValue
+    $updatedSettings = $CdfConfig | Get-CdfServiceConfigSettings -UseEnv -UpdateSettings $defaultSettings -SecretValue
     Write-Verbose "Writing: $InputEnv"
     $updatedSettings | ConvertTo-CdfDotEnv | Set-Content -Path $OutputEnv
 }

--- a/CDFModule/Public/func_Get-ServiceConfigSettings.ps1
+++ b/CDFModule/Public/func_Get-ServiceConfigSettings.ps1
@@ -14,8 +14,19 @@ Function Get-ServiceConfigSettings {
         Existing settings. New settings will be attched to it.
         Optional
 
+        .PARAMETER Deployed
+        When specified, retrieves CdfConfig from deployed state if CdfConfig is not provided.
+
         .PARAMETER SecretValue
-        When this paramter/switch is enabled the command will fetch the actual secret value from KeyVault instead of a reference.
+        When this parameter/switch is enabled the command will fetch the actual secret value from KeyVault instead of a reference.
+
+        .PARAMETER UseCS
+        Pass -UseCS to Add-ServiceConnectionSettings to produce connection string style settings
+        with Key Vault references. Used for Azure App Service / Logic Apps deployment.
+
+        .PARAMETER UseEnv
+        Pass -UseEnv to Add-ServiceConnectionSettings to produce environment variable style settings
+        with uppercase suffixes and resolved secrets. Used for container local development (.env files).
 
         .PARAMETER ConfigFileName
         This optional parameter allows to reference a different config file name than the default 'cdf-config.json'.
@@ -70,7 +81,9 @@ Function Get-ServiceConfigSettings {
         [Parameter(Mandatory = $false)]
         [string] $TemplateDir = $env:CDF_INFRA_TEMPLATES_PATH ?? ".",
         [Parameter(Mandatory = $false)]
-        [switch] $UseCS
+        [switch] $UseCS,
+        [Parameter(Mandatory = $false)]
+        [switch] $UseEnv
 
     )
 
@@ -219,6 +232,14 @@ Function Get-ServiceConfigSettings {
                 Write-Host "`tConnection setting for $connectionName"
                 if ($UseCS) {
                     $UpdateSettings = Add-ServiceConnectionSettings -UseCS `
+                        -Settings $UpdateSettings `
+                        -CdfConfig $CdfConfig `
+                        -ConnectionDefinition $definition `
+                        -ConnectionName $connectionName `
+                        -ParameterName $definition.ConnectionKey
+                }
+                elseif ($UseEnv) {
+                    $UpdateSettings = Add-ServiceConnectionSettings -UseEnv `
                         -Settings $UpdateSettings `
                         -CdfConfig $CdfConfig `
                         -ConnectionDefinition $definition `


### PR DESCRIPTION
## Summary

Adds a third connection settings mode (`-UseEnv`) for generating `.env` files with resolved credentials suitable for local container development.

## Changes

- **`func_Add-ServiceConnectionSettings.ps1`** — New `UseEnv` block producing uppercase suffixes without underscores (`CONNECTIONSTRING`, `SERVERNAME`, `USERNAME`, `PASSWORD`, etc.) with secrets resolved from Key Vault at generation time
- **`func_Get-ServiceConfigSettings.ps1`** — Added `-UseEnv` parameter and routing to `Add-ServiceConnectionSettings` (previously the flag was silently ignored)
- **`func_Export-DotEnv.ps1`** — Uses `-UseEnv` for container local dev

## Three connection modes

| Mode | Flag | Use case | Secrets |
|------|------|----------|---------|
| Managed Identity | *(default)* | Azure deployed containers/apps | URIs only |
| Connection String | `-UseCS` | Logic Apps / Function Apps | KV references |
| Environment | `-UseEnv` | Local container dev (.env) | Resolved plaintext |

Fixes #64