### PR TITLE
chore: test harness, CI automation, and pre-commit formatting

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,5 @@
+#!/bin/sh
+# CDFModule pre-commit hook.
+# Auto-formats staged PowerShell files with PSScriptAnalyzer. Delegates to a
+# PowerShell script so the logic is cross-platform.
+exec pwsh -NoProfile -File "$(dirname "$0")/pre-commit.ps1"

--- a/.githooks/pre-commit.ps1
+++ b/.githooks/pre-commit.ps1
@@ -1,0 +1,34 @@
+#!/usr/bin/env pwsh
+# Auto-format staged PowerShell files using the repo PSScriptAnalyzer settings,
+# then re-stage anything that changed. Never blocks the commit — the CI lint gate
+# is the enforcement point; this hook just keeps formatting consistent.
+$ErrorActionPreference = 'Stop'
+
+$staged = git diff --cached --name-only --diff-filter=ACMR -- '*.ps1' |
+    Where-Object { $_ -and (Test-Path $_) }
+if (-not $staged) { exit 0 }
+
+if (-not (Get-Module -ListAvailable PSScriptAnalyzer)) {
+    Write-Warning 'pre-commit: PSScriptAnalyzer not installed; skipping auto-format. (Install-Module PSScriptAnalyzer)'
+    exit 0
+}
+Import-Module PSScriptAnalyzer
+
+$root = (git rev-parse --show-toplevel).Trim()
+$settings = Join-Path $root 'PSScriptAnalyzerSettings.psd1'
+$fixed = @()
+
+foreach ($file in $staged) {
+    $before = Get-Content -Raw -- $file
+    Invoke-ScriptAnalyzer -Path $file -Settings $settings -Fix | Out-Null
+    $after = Get-Content -Raw -- $file
+    if ($before -ne $after) {
+        git add -- $file
+        $fixed += $file
+    }
+}
+
+if ($fixed) {
+    Write-Host "pre-commit: auto-formatted and re-staged:`n  $($fixed -join "`n  ")"
+}
+exit 0

--- a/.github/workflows/prerelease-cdfmodule.yaml
+++ b/.github/workflows/prerelease-cdfmodule.yaml
@@ -25,6 +25,8 @@ jobs:
           New-Item -Type Directory release | Out-Null
           Copy-Item -Recurse -Path CDFModule -Destination release
           cd release
+          # Do not ship co-located Pester tests in the published module
+          Get-ChildItem -Path ./CDFModule -Recurse -Filter '*.Tests.ps1' | Remove-Item -Force
           $releaseTag="${{ github.ref_name }}"
           $releaseVersion=$releaseTag.TrimStart("v")
           #Install CDFModule required dependency

--- a/.github/workflows/release-cdfmodule.yaml
+++ b/.github/workflows/release-cdfmodule.yaml
@@ -25,6 +25,8 @@ jobs:
           New-Item -Type Directory release | Out-Null
           Copy-Item -Recurse -Path CDFModule -Destination release
           cd release
+          # Do not ship co-located Pester tests in the published module
+          Get-ChildItem -Path ./CDFModule -Recurse -Filter '*.Tests.ps1' | Remove-Item -Force
           $releaseTag="${{ github.ref_name }}"
           $releaseVersion=$releaseTag.TrimStart("v")
           #Install CDFModule required dependency

--- a/.github/workflows/test-cdfmodule.yaml
+++ b/.github/workflows/test-cdfmodule.yaml
@@ -1,0 +1,50 @@
+name: "test-cdfmodule"
+
+on:
+  pull_request:
+    branches: ["main"]
+  push:
+    branches: ["main"]
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    name: Lint (changed files)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install PSScriptAnalyzer
+        shell: pwsh
+        run: Install-Module PSScriptAnalyzer -Force -Scope CurrentUser
+
+      - name: Analyze changed PowerShell files
+        shell: pwsh
+        run: ./tools/Invoke-Lint.ps1 -Changed
+
+  test:
+    name: Pester
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Pester
+        shell: pwsh
+        run: Install-Module Pester -MinimumVersion 5.5.0 -Force -Scope CurrentUser
+
+      - name: Run Pester
+        shell: pwsh
+        run: ./tools/Invoke-Tests.ps1 -CI
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pester-results
+          path: ./testResults.xml

--- a/CDFModule/CDFModule.psm1
+++ b/CDFModule/CDFModule.psm1
@@ -1,14 +1,16 @@
 ﻿#Requires -Modules @{ ModuleName="Az.ResourceGraph"; ModuleVersion="1.0.0" }
 
-Get-ChildItem (Split-Path $script:MyInvocation.MyCommand.Path) -Filter 'func_*.ps1' -Recurse | ForEach-Object {
-  # Write-Verbose ($_.FullName)
-  . $_.FullName
-}
-Get-ChildItem "$(Split-Path $script:MyInvocation.MyCommand.Path)\Public\*" -Filter 'func_*.ps1' -Recurse | ForEach-Object {
-  # Write-Verbose """$(($_.BaseName -Split "_")[1])"""
-  Export-ModuleMember -Function ($_.BaseName -Split "_")[1]
-  Export-ModuleMember ($_.BaseName -Split "_")[1]
-}
+Get-ChildItem (Split-Path $script:MyInvocation.MyCommand.Path) -Filter 'func_*.ps1' -Recurse |
+  Where-Object { $_.Name -notlike '*.Tests.ps1' } | ForEach-Object {
+    # Write-Verbose ($_.FullName)
+    . $_.FullName
+  }
+Get-ChildItem "$(Split-Path $script:MyInvocation.MyCommand.Path)\Public\*" -Filter 'func_*.ps1' -Recurse |
+  Where-Object { $_.Name -notlike '*.Tests.ps1' } | ForEach-Object {
+    # Write-Verbose """$(($_.BaseName -Split "_")[1])"""
+    Export-ModuleMember -Function ($_.BaseName -Split "_")[1]
+    Export-ModuleMember ($_.BaseName -Split "_")[1]
+  }
 
 Set-Alias -Scope Global -Name cdf-profile -Value "Import-CdfProfile" -Description "Load the standard CDFModule profile which includes customized prompt."
 

--- a/CDFModule/Private/func_CdfRegistry.Tests.ps1
+++ b/CDFModule/Private/func_CdfRegistry.Tests.ps1
@@ -1,0 +1,94 @@
+BeforeAll {
+    # Dot-source the function under test (private, not exported by the module).
+    $testFolder = Split-Path -Parent $PSCommandPath
+    $sourceFile = (Split-Path -Leaf $PSCommandPath).Replace('.Tests.', '.')
+    . (Join-Path $testFolder $sourceFile)
+}
+
+Describe 'New-CdfRegistryProvider' {
+
+    Context 'OCI registry' {
+        It 'creates an OCI provider whose PasswordEnvVar is the env-var NAME ([string])' {
+            $provider = New-CdfRegistryProvider -RegistryConfig @{
+                type     = 'oci'
+                endpoint = 'reg.example.com/cdf'
+            }
+
+            $provider.Type | Should -Be 'oci'
+            $provider.Endpoint | Should -Be 'reg.example.com/cdf'
+            $provider.Username | Should -Be 'cdf'
+
+            # Regression guard: PasswordEnvVar holds the NAME of an environment
+            # variable (a plain string), not a SecureString. Retyping the
+            # constructor parameter to [SecureString] breaks construction because
+            # the factory passes a [string] default ('CDF_REGISTRY_TOKEN').
+            $provider.PasswordEnvVar | Should -BeOfType [string]
+            $provider.PasswordEnvVar | Should -Be 'CDF_REGISTRY_TOKEN'
+        }
+
+        It 'honours an explicit username and passwordEnvVar' {
+            $provider = New-CdfRegistryProvider -RegistryConfig @{
+                type           = 'oci'
+                endpoint       = 'reg.example.com/cdf'
+                username       = 'svc-cdf'
+                passwordEnvVar = 'MY_TOKEN'
+            }
+
+            $provider.Username | Should -Be 'svc-cdf'
+            $provider.PasswordEnvVar | Should -Be 'MY_TOKEN'
+        }
+    }
+
+    Context 'ACR registry' {
+        It 'creates an ACR provider' {
+            $provider = New-CdfRegistryProvider -RegistryConfig @{
+                type     = 'acr'
+                endpoint = 'myreg.azurecr.io'
+            }
+
+            $provider.Type | Should -Be 'acr'
+            $provider.Endpoint | Should -Be 'myreg.azurecr.io'
+        }
+    }
+
+    Context 'Unsupported registry' {
+        It 'throws for an unknown registry type' {
+            { New-CdfRegistryProvider -RegistryConfig @{ type = 'nope'; endpoint = 'x' } } |
+                Should -Throw -ExpectedMessage '*Unsupported registry type*'
+        }
+    }
+}
+
+Describe 'Resolve-CdfRegistryConfig' {
+
+    It 'resolves a project-level registry file first' {
+        $projectDir = Join-Path $TestDrive 'proj'
+        $registriesDir = Join-Path $projectDir '.cdf/registries'
+        New-Item -ItemType Directory -Path $registriesDir -Force | Out-Null
+        @{ type = 'acr'; endpoint = 'proj.azurecr.io' } | ConvertTo-Json |
+            Set-Content -Path (Join-Path $registriesDir 'default.json')
+
+        $config = Resolve-CdfRegistryConfig -Name 'default' -ProjectDir $projectDir
+
+        $config.type | Should -Be 'acr'
+        $config.endpoint | Should -Be 'proj.azurecr.io'
+    }
+
+    It 'falls back to inline registries from the manifest' {
+        $projectDir = Join-Path $TestDrive 'empty'
+        New-Item -ItemType Directory -Path $projectDir -Force | Out-Null
+        $inline = @{ 'cdf-pkgs' = @{ type = 'oci'; endpoint = 'ghcr.io/epical' } }
+
+        $config = Resolve-CdfRegistryConfig -Name 'cdf-pkgs' -InlineRegistries $inline -ProjectDir $projectDir
+
+        $config.endpoint | Should -Be 'ghcr.io/epical'
+    }
+
+    It 'throws when the registry cannot be resolved' {
+        $projectDir = Join-Path $TestDrive 'unresolved'
+        New-Item -ItemType Directory -Path $projectDir -Force | Out-Null
+
+        { Resolve-CdfRegistryConfig -Name 'cdf-no-such-registry-xyz' -ProjectDir $projectDir } |
+            Should -Throw -ExpectedMessage '*not found*'
+    }
+}

--- a/CDFModule/Private/func_GeneratePassword.Tests.ps1
+++ b/CDFModule/Private/func_GeneratePassword.Tests.ps1
@@ -1,0 +1,52 @@
+BeforeAll {
+    # Dot-source the function under test (private, not exported by the module).
+    $testFolder = Split-Path -Parent $PSCommandPath
+    $sourceFile = (Split-Path -Leaf $PSCommandPath).Replace('.Tests.', '.')
+    . (Join-Path $testFolder $sourceFile)
+
+    function Get-PlainPassword {
+        param([System.Security.SecureString]$Secure)
+        [System.Net.NetworkCredential]::new('', $Secure).Password
+    }
+
+    $script:UpperSet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
+    $script:LowerSet = 'abcdefghijklmnopqrstuvwxyz'
+    $script:NumberSet = '0123456789'
+    $script:SpecialSet = '*-+,!=._'
+}
+
+Describe 'GeneratePassword' {
+
+    It 'returns a SecureString' {
+        GeneratePassword | Should -BeOfType [System.Security.SecureString]
+    }
+
+    It 'defaults to a length of 12' {
+        $plain = Get-PlainPassword (GeneratePassword)
+        $plain.Length | Should -Be 12
+    }
+
+    It 'generates a password of the requested length' {
+        $plain = Get-PlainPassword (GeneratePassword -Length 14)
+        $plain.Length | Should -Be 14
+    }
+
+    It 'satisfies the requested minimum for each character class' {
+        $plain = Get-PlainPassword (GeneratePassword -Length 16 -Upper 2 -Lower 2 -Numeric 2 -Special 2)
+        $chars = $plain.ToCharArray()
+
+        @($chars | Where-Object { $script:UpperSet.Contains($_) }).Count | Should -BeGreaterOrEqual 2
+        @($chars | Where-Object { $script:LowerSet.Contains($_) }).Count | Should -BeGreaterOrEqual 2
+        @($chars | Where-Object { $script:NumberSet.Contains($_) }).Count | Should -BeGreaterOrEqual 2
+        @($chars | Where-Object { $script:SpecialSet.Contains($_) }).Count | Should -BeGreaterOrEqual 2
+    }
+
+    It 'throws when class minimums exceed the length' {
+        { GeneratePassword -Length 8 -Upper 3 -Lower 3 -Numeric 3 -Special 3 } |
+            Should -Throw -ExpectedMessage '*less than or equal to length*'
+    }
+
+    It 'rejects a length outside the allowed range (8-16)' {
+        { GeneratePassword -Length 4 } | Should -Throw
+    }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Pester test harness with co-located unit tests; `test-cdfmodule` CI workflow runs lint and tests on pull requests (PR #67)
+- Unit tests for the `CdfRegistry` provider factory/resolver and `GeneratePassword` (PR #67)
+- Pre-commit hook that auto-formats staged PowerShell with PSScriptAnalyzer, plus `tools/Install-GitHooks.ps1` to install it (PR #67)
+
+### Changed
+
+- Module loader and release packaging now exclude `*.Tests.ps1`, so co-located tests are neither imported at runtime nor published to the gallery (PR #67)
+
 ### Fixed
 
 - Container apps env vars with both SecretRef and Value properties (PR #46, 2025-11-07)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,16 @@ Thank you for contributing to the Epical Cloud Deployment Framework module.
 - [Pester](https://www.powershellgallery.com/packages/Pester) v5+ for tests
 - [GitHub CLI](https://cli.github.com/) (`gh`) for issue/PR management
 
+## Local Setup
+
+After cloning, install the git hooks once:
+
+```powershell
+./tools/Install-GitHooks.ps1
+```
+
+The `pre-commit` hook auto-formats staged PowerShell files with PSScriptAnalyzer using the repo settings. Continuous integration (the `test-cdfmodule` workflow) runs the linter on changed files and the full Pester suite on every pull request.
+
 ## Workflow
 
 ### 1. Create an Issue

--- a/tools/Install-GitHooks.ps1
+++ b/tools/Install-GitHooks.ps1
@@ -1,0 +1,15 @@
+<#
+.SYNOPSIS
+    Installs the repo git hooks by pointing core.hooksPath at .githooks.
+.DESCRIPTION
+    Run once after cloning. The pre-commit hook auto-formats staged PowerShell
+    files with PSScriptAnalyzer using the repo settings.
+.EXAMPLE
+    ./build/Install-GitHooks.ps1
+#>
+[CmdletBinding()]
+param()
+
+$root = (git rev-parse --show-toplevel).Trim()
+git -C $root config core.hooksPath .githooks
+Write-Host "Git hooks installed: core.hooksPath = .githooks (repo: $root)"

--- a/tools/Invoke-Lint.ps1
+++ b/tools/Invoke-Lint.ps1
@@ -1,0 +1,60 @@
+<#
+.SYNOPSIS
+    Runs PSScriptAnalyzer over the module using the repo settings.
+.DESCRIPTION
+    Default mode lints the whole module and reports issues. The -Changed mode
+    lints only PowerShell files changed versus a base ref and fails (exit 1) on
+    any issue — used as a ratcheting CI gate so new violations are blocked while
+    the existing backlog does not wall off unrelated PRs.
+.EXAMPLE
+    ./build/Invoke-Lint.ps1
+.EXAMPLE
+    ./build/Invoke-Lint.ps1 -Changed -BaseRef origin/main
+#>
+[CmdletBinding()]
+param(
+    [string]$Path = './CDFModule',
+    [switch]$Changed,
+    [string]$BaseRef,
+    [string]$SettingsPath = './PSScriptAnalyzerSettings.psd1'
+)
+
+Import-Module PSScriptAnalyzer -ErrorAction Stop
+
+function Get-ChangedPowerShellFile {
+    param([string]$BaseRef)
+
+    if (-not $BaseRef) {
+        if ($env:GITHUB_BASE_REF) { $BaseRef = "origin/$($env:GITHUB_BASE_REF)" }
+        else { $BaseRef = 'HEAD~1' }
+    }
+
+    $diff = git diff --name-only --diff-filter=ACMR "$BaseRef...HEAD" -- '*.ps1'
+    return @($diff | Where-Object { $_ -and (Test-Path $_) })
+}
+
+if ($Changed) {
+    $files = Get-ChangedPowerShellFile -BaseRef $BaseRef
+    if (-not $files) {
+        Write-Host 'Lint: no changed PowerShell files.'
+        exit 0
+    }
+    Write-Host "Lint: analyzing changed files:`n  $($files -join "`n  ")"
+    $results = foreach ($file in $files) {
+        Invoke-ScriptAnalyzer -Path $file -Settings $SettingsPath
+    }
+}
+else {
+    Write-Host "Lint: analyzing '$Path' (recursive)."
+    $results = Invoke-ScriptAnalyzer -Path $Path -Settings $SettingsPath -Recurse
+}
+
+$results = @($results)
+if ($results.Count -gt 0) {
+    $results | Format-Table -AutoSize | Out-String | Write-Host
+    Write-Host "PSScriptAnalyzer found $($results.Count) issue(s)."
+    exit 1
+}
+
+Write-Host 'PSScriptAnalyzer: no issues.'
+exit 0

--- a/tools/Invoke-Tests.ps1
+++ b/tools/Invoke-Tests.ps1
@@ -1,0 +1,32 @@
+<#
+.SYNOPSIS
+    Runs the CDFModule Pester test suite.
+.DESCRIPTION
+    Thin wrapper around Pester 5 used both locally and in CI. Discovers
+    co-located *.Tests.ps1 files under the module path.
+.EXAMPLE
+    ./build/Invoke-Tests.ps1
+.EXAMPLE
+    ./build/Invoke-Tests.ps1 -CI   # emit NUnit results and fail the process on test failure
+#>
+[CmdletBinding()]
+param(
+    [string]$Path = './CDFModule',
+    [switch]$CI
+)
+
+Import-Module Pester -MinimumVersion 5.5.0 -ErrorAction Stop
+
+$config = New-PesterConfiguration
+$config.Run.Path = $Path
+$config.Output.Verbosity = 'Detailed'
+
+if ($CI) {
+    $config.TestResult.Enabled = $true
+    $config.TestResult.OutputPath = './testResults.xml'
+    $config.TestResult.OutputFormat = 'NUnitXml'
+    # Throw (non-zero exit) when any test fails so the CI job is marked failed.
+    $config.Run.Throw = $true
+}
+
+Invoke-Pester -Configuration $config


### PR DESCRIPTION
Establishes the testing/quality-automation foundation for CDFModule. First delivery under #57.

Fixes #66

## What's included
- **Test harness** — `tools/Invoke-Tests.ps1` (Pester 5); co-located `func_*.Tests.ps1` convention.
- **CI** — `test-cdfmodule` workflow: PSScriptAnalyzer lint on **changed files** (ratcheting gate, so the ~26 legacy warnings don't block) + Pester on every PR.
- **Pre-commit formatting** — `.githooks/pre-commit` auto-formats staged PowerShell via PSScriptAnalyzer; install with `tools/Install-GitHooks.ps1`.
- **First private-function unit tests** — `CdfRegistry` (provider factory acr/oci/unknown, layered `Resolve-CdfRegistryConfig`, and a regression guard that `PasswordEnvVar` stays a `[string]` env-var name) and `GeneratePassword`.

## Correctness fixes folded in
- **Loader**: `CDFModule.psm1` excludes `*.Tests.ps1` — without this, co-located tests are dot-sourced at `Import-Module` time and execute Pester blocks. Verified import is clean (98 commands export).
- **Packaging**: `release`/`prerelease` workflows strip `*.Tests.ps1` so tests aren't published to the gallery.

## Verification
- 13/13 tests pass via `tools/Invoke-Tests.ps1`.
- All new `.ps1` files pass the analyzer (the changed-files gate is clean).
- Regression guard proven: the correct `[string]` constructs; a `[SecureString]` retype throws.

## Notes
- Scripts live in `tools/` because `build/` is gitignored (build output).
- #66 should be linked as a formal **sub-issue of #57** — the API rejected it under contributor permissions (`FORBIDDEN`); a maintainer can link it via *Create sub-issue → Add existing issue*.