### PR TITLE
fix: service name precedence — explicit > env > ServiceDefaults (#76)

### DIFF
--- a/CDFModule/Public/func_Get-Config.Tests.ps1
+++ b/CDFModule/Public/func_Get-Config.Tests.ps1
@@ -1,0 +1,55 @@
+BeforeAll {
+    $testFolder = Split-Path -Parent $PSCommandPath
+    . (Join-Path $testFolder 'func_Get-Config.ps1')
+    . (Join-Path $testFolder 'func_Get-ConfigService.ps1')   # real forward target (+ Get-InfraServiceConfig)
+
+    # Stub the platform/application/domain loaders — not under test here. Return a *deployed* domain
+    # so Get-Config reaches the Get-ConfigService forward (line: $ServiceName -and $config.Domain.IsDeployed).
+    function Get-ConfigPlatform {
+        [CmdletBinding()] param($Region, $PlatformId, $Instance, $EnvDefinitionId, $SourceDir, [switch]$Deployed)
+        @{ Platform = @{ Config = @{ platformId = 'test'; instanceId = '01' }; Env = @{ nameId = 'lcl'; regionCode = 'we'; region = 'westeurope'; subscriptionId = '0' } } }
+    }
+    function Get-ConfigApplication {
+        [CmdletBinding()] param($CdfConfig, $Region, $ApplicationId, $InstanceId, $EnvDefinitionId, $SourceDir, [switch]$Deployed)
+        $CdfConfig.Application = @{ Config = @{ applicationId = 'app'; instanceId = '01' }; Env = @{ nameId = 'lcl'; name = 'Local' } }
+        $CdfConfig
+    }
+    function Get-ConfigDomain {
+        [CmdletBinding()] param($CdfConfig, $DomainName, $SourceDir, [switch]$Deployed)
+        $CdfConfig.Domain = @{ Config = @{ domainName = 'dom1' }; IsDeployed = $true; ResourceNames = @{} }
+        $CdfConfig
+    }
+}
+
+Describe 'Get-Config -> Get-ConfigService chain — service name precedence (#76)' {
+
+    BeforeEach {
+        Remove-Item Env:/CDF_SERVICE_NAME -ErrorAction SilentlyContinue
+        $script:src = Join-Path $TestDrive 'src'
+        New-Item -ItemType Directory -Path (Join-Path $script:src 'test/01') -Force | Out-Null   # Get-Config source-path existence check
+        $script:svcSrc = Join-Path $TestDrive 'svc'
+        New-Item -ItemType Directory -Path $script:svcSrc -Force | Out-Null
+        @{ ServiceDefaults = @{ ServiceName = 'umbraco-cms'; ServiceGroup = 'web'; ServiceType = 'dotnet'; ServiceTemplate = 'containerapp-api-v1' } } |
+            ConvertTo-Json | Set-Content -Path (Join-Path $script:svcSrc 'cdf-config.json')
+        Mock Test-Json { $true }
+    }
+
+    AfterEach { Remove-Item Env:/CDF_SERVICE_NAME -ErrorAction SilentlyContinue }
+
+    It 'env CDF_SERVICE_NAME flows through Get-Config into the service config (the deploy path)' {
+        $env:CDF_SERVICE_NAME = 'umbraco-web'
+        $cfg = Get-Config -PlatformId test -PlatformInstance 01 -DomainName dom1 -CdfInfraSourcePath $script:src -ServiceSrcPath $script:svcSrc
+        $cfg.Service.Config.serviceName | Should -BeExactly 'umbraco-web'
+    }
+
+    It 'explicit -ServiceName overrides env through the chain' {
+        $env:CDF_SERVICE_NAME = 'umbraco-web'
+        $cfg = Get-Config -ServiceName explicit-svc -PlatformId test -PlatformInstance 01 -DomainName dom1 -CdfInfraSourcePath $script:src -ServiceSrcPath $script:svcSrc
+        $cfg.Service.Config.serviceName | Should -BeExactly 'explicit-svc'
+    }
+
+    It 'ServiceDefaults used when neither param nor env is set (regression guard)' {
+        $cfg = Get-Config -PlatformId test -PlatformInstance 01 -DomainName dom1 -CdfInfraSourcePath $script:src -ServiceSrcPath $script:svcSrc
+        $cfg.Service.Config.serviceName | Should -BeExactly 'umbraco-cms'
+    }
+}

--- a/CDFModule/Public/func_Get-Config.ps1
+++ b/CDFModule/Public/func_Get-Config.ps1
@@ -206,10 +206,26 @@ Function Get-Config {
     }
     $svcConfig = Get-Content -Raw $cdfConfigFile | ConvertFrom-Json -AsHashtable
 
-    $ServiceName = $MyInvocation.BoundParameters.Keys.Contains("ServiceName") ? $ServiceName : $svcConfig.ServiceDefaults.ServiceName
-    $ServiceGroup = $MyInvocation.BoundParameters.Keys.Contains("ServiceGroup") ? $ServiceGroup : $svcConfig.ServiceDefaults.ServiceGroup
-    $ServiceType = $MyInvocation.BoundParameters.Keys.Contains("ServiceType") ? $ServiceType : $svcConfig.ServiceDefaults.ServiceType
-    $ServiceTemplate = $MyInvocation.BoundParameters.Keys.Contains("ServiceTemplate") ? $ServiceTemplate : $svcConfig.ServiceDefaults.ServiceTemplate
+    # Precedence: explicit -Service* param > $env:CDF_SERVICE_* (via the parameter default) > cdf-config ServiceDefaults.
+    # The parameter already holds explicit-or-env (PowerShell only applies the default when the param is unbound), so a
+    # truthiness check restores the env layer that a BoundParameters test discards. Must be ?: not ?? — the [string]
+    # default is '' (not $null) when the env var is unset, so ?? would not fall through to ServiceDefaults.
+    $ServiceName = $ServiceName ? $ServiceName : $svcConfig.ServiceDefaults.ServiceName
+    $ServiceGroup = $ServiceGroup ? $ServiceGroup : $svcConfig.ServiceDefaults.ServiceGroup
+    $ServiceType = $ServiceType ? $ServiceType : $svcConfig.ServiceDefaults.ServiceType
+    $ServiceTemplate = $ServiceTemplate ? $ServiceTemplate : $svcConfig.ServiceDefaults.ServiceTemplate
+
+    # Surface CDF_SERVICE_* env overrides so an unintended one in the environment is easy to spot.
+    foreach ($o in @(
+        @{ Param = 'ServiceName'; Env = 'CDF_SERVICE_NAME'; Value = $ServiceName },
+        @{ Param = 'ServiceGroup'; Env = 'CDF_SERVICE_GROUP'; Value = $ServiceGroup },
+        @{ Param = 'ServiceType'; Env = 'CDF_SERVICE_TYPE'; Value = $ServiceType },
+        @{ Param = 'ServiceTemplate'; Env = 'CDF_SERVICE_TEMPLATE'; Value = $ServiceTemplate }
+      )) {
+      if (-not $MyInvocation.BoundParameters.ContainsKey($o.Param) -and [Environment]::GetEnvironmentVariable($o.Env)) {
+        Write-Verbose "Get-CdfConfig: $($o.Param) from `$env:$($o.Env) override = '$($o.Value)' (cdf-config ServiceDefaults.$($o.Param) not applied)"
+      }
+    }
   }
 
   if ($Deployed) {

--- a/CDFModule/Public/func_Get-ConfigService.Tests.ps1
+++ b/CDFModule/Public/func_Get-ConfigService.Tests.ps1
@@ -1,0 +1,74 @@
+BeforeAll {
+    $testFolder = Split-Path -Parent $PSCommandPath
+    . (Join-Path $testFolder 'func_Get-ConfigService.ps1')   # also defines Get-InfraServiceConfig
+
+    function New-TestCdfConfig {
+        @{
+            Platform    = @{
+                Config = @{ platformId = 'test'; instanceId = '01' }
+                Env    = @{ nameId = 'lcl'; regionCode = 'we'; region = 'westeurope'; subscriptionId = '00000000-0000-0000-0000-000000000000' }
+            }
+            Application = @{
+                Config = @{ applicationId = 'app'; instanceId = '01' }
+                Env    = @{ nameId = 'lcl'; name = 'Local' }
+            }
+            Domain      = @{ Config = @{ domainName = 'dom1' }; IsDeployed = $true; ResourceNames = @{} }
+        }
+    }
+}
+
+Describe 'Get-ConfigService — service name precedence (explicit > env > ServiceDefaults)' {
+
+    BeforeEach {
+        Remove-Item Env:/CDF_SERVICE_NAME -ErrorAction SilentlyContinue
+        # cdf-config.json with ServiceDefaults at the service source path
+        $script:svcSrc = Join-Path $TestDrive 'svc'
+        New-Item -ItemType Directory -Path $script:svcSrc -Force | Out-Null
+        @{ ServiceDefaults = @{ ServiceName = 'umbraco-cms'; ServiceGroup = 'web'; ServiceType = 'dotnet'; ServiceTemplate = 'containerapp-api-v1' } } |
+            ConvertTo-Json | Set-Content -Path (Join-Path $script:svcSrc 'cdf-config.json')
+        # No infra service.*.json -> Get-InfraServiceConfig returns Config.serviceName = the resolved value
+        $script:noSrc = Join-Path $TestDrive 'no-infra-src'
+        Mock Test-Json { $true }   # bypass JSON-schema validation for the unit test
+    }
+
+    AfterEach { Remove-Item Env:/CDF_SERVICE_NAME -ErrorAction SilentlyContinue }
+
+    It 'explicit -ServiceName wins over env and ServiceDefaults' {
+        $env:CDF_SERVICE_NAME = 'umbraco-web'
+        $cfg = New-TestCdfConfig | Get-ConfigService -ServiceName 'explicit-svc' -ServiceSrcPath $script:svcSrc -SourceDir $script:noSrc
+        $cfg.Service.Config.serviceName | Should -BeExactly 'explicit-svc'
+    }
+
+    It 'env CDF_SERVICE_NAME wins over ServiceDefaults when -ServiceName is not passed' {
+        $env:CDF_SERVICE_NAME = 'umbraco-web'
+        $cfg = New-TestCdfConfig | Get-ConfigService -ServiceSrcPath $script:svcSrc -SourceDir $script:noSrc
+        $cfg.Service.Config.serviceName | Should -BeExactly 'umbraco-web'
+    }
+
+    It 'falls back to cdf-config ServiceDefaults when neither param nor env is set' {
+        $cfg = New-TestCdfConfig | Get-ConfigService -ServiceSrcPath $script:svcSrc -SourceDir $script:noSrc
+        $cfg.Service.Config.serviceName | Should -BeExactly 'umbraco-cms'
+    }
+
+    It 'env override of ServiceName does not bleed into the other fields' {
+        $env:CDF_SERVICE_NAME = 'umbraco-web'
+        $cfg = New-TestCdfConfig | Get-ConfigService -ServiceSrcPath $script:svcSrc -SourceDir $script:noSrc
+        $cfg.Service.Config.serviceName | Should -BeExactly 'umbraco-web'
+        $cfg.Service.Config.serviceGroup | Should -BeExactly 'web'           # from ServiceDefaults
+        $cfg.Service.Config.serviceTemplate | Should -BeExactly 'containerapp-api-v1'
+    }
+
+    It 'emits a Verbose note when the CDF_SERVICE_NAME env override is in effect' {
+        $env:CDF_SERVICE_NAME = 'umbraco-web'
+        $verbose = New-TestCdfConfig | Get-ConfigService -ServiceSrcPath $script:svcSrc -SourceDir $script:noSrc -Verbose 4>&1 |
+            Where-Object { $_ -is [System.Management.Automation.VerboseRecord] -and $_.Message -match 'CDF_SERVICE_NAME override' }
+        $verbose | Should -Not -BeNullOrEmpty
+    }
+
+    It 'does not emit the override note when -ServiceName is explicit' {
+        $env:CDF_SERVICE_NAME = 'umbraco-web'
+        $verbose = New-TestCdfConfig | Get-ConfigService -ServiceName 'explicit-svc' -ServiceSrcPath $script:svcSrc -SourceDir $script:noSrc -Verbose 4>&1 |
+            Where-Object { $_ -is [System.Management.Automation.VerboseRecord] -and $_.Message -match 'CDF_SERVICE_NAME override' }
+        $verbose | Should -BeNullOrEmpty
+    }
+}

--- a/CDFModule/Public/func_Get-ConfigService.ps1
+++ b/CDFModule/Public/func_Get-ConfigService.ps1
@@ -79,7 +79,7 @@
     $cdfConfigFile = Join-Path -Path $ServiceSrcPath  -ChildPath 'cdf-config.json'
     if (Test-Path $cdfConfigFile) {
       Write-Verbose "Loading cdf-config.json file"
-      $cdfSchemaPath = Join-Path -Path $MyInvocation.MyCommand.Module.ModuleBase -ChildPath 'Resources/Schemas/cdf-service-config.schema.json'
+      $cdfSchemaPath = Join-Path -Path $PSScriptRoot -ChildPath '../Resources/Schemas/cdf-service-config.schema.json'
       if (!(Test-Json -SchemaFile $cdfSchemaPath -Path $cdfConfigFile)) {
         Write-Error "Service configuration file did not validate. Please check errors above and correct."
         Write-Error "File path:  $cdfConfigFile"
@@ -88,10 +88,26 @@
 
       $serviceCdfConfig = Get-Content $cdfConfigFile | ConvertFrom-Json -AsHashtable
 
-      $ServiceName = $MyInvocation.BoundParameters.Keys.Contains("ServiceName") ? $ServiceName : $serviceCdfConfig.ServiceDefaults.ServiceName
-      $ServiceGroup = $MyInvocation.BoundParameters.Keys.Contains("ServiceGroup") ? $ServiceGroup : $serviceCdfConfig.ServiceDefaults.ServiceGroup
-      $ServiceType = $MyInvocation.BoundParameters.Keys.Contains("ServiceType") ? $ServiceType : $serviceCdfConfig.ServiceDefaults.ServiceType
-      $ServiceTemplate = $MyInvocation.BoundParameters.Keys.Contains("ServiceTemplate") ? $ServiceTemplate : $serviceCdfConfig.ServiceDefaults.ServiceTemplate
+      # Precedence: explicit -Service* param > $env:CDF_SERVICE_* (via the parameter default) > cdf-config ServiceDefaults.
+      # The parameter already holds explicit-or-env (PowerShell only applies the default when the param is unbound), so a
+      # truthiness check restores the env layer that a BoundParameters test discards. Must be ?: not ?? — the [string]
+      # default is '' (not $null) when the env var is unset, so ?? would not fall through to ServiceDefaults.
+      $ServiceName = $ServiceName ? $ServiceName : $serviceCdfConfig.ServiceDefaults.ServiceName
+      $ServiceGroup = $ServiceGroup ? $ServiceGroup : $serviceCdfConfig.ServiceDefaults.ServiceGroup
+      $ServiceType = $ServiceType ? $ServiceType : $serviceCdfConfig.ServiceDefaults.ServiceType
+      $ServiceTemplate = $ServiceTemplate ? $ServiceTemplate : $serviceCdfConfig.ServiceDefaults.ServiceTemplate
+
+      # Surface CDF_SERVICE_* env overrides so an unintended one in the environment is easy to spot.
+      foreach ($o in @(
+          @{ Param = 'ServiceName'; Env = 'CDF_SERVICE_NAME'; Value = $ServiceName },
+          @{ Param = 'ServiceGroup'; Env = 'CDF_SERVICE_GROUP'; Value = $ServiceGroup },
+          @{ Param = 'ServiceType'; Env = 'CDF_SERVICE_TYPE'; Value = $ServiceType },
+          @{ Param = 'ServiceTemplate'; Env = 'CDF_SERVICE_TEMPLATE'; Value = $ServiceTemplate }
+        )) {
+        if (-not $MyInvocation.BoundParameters.ContainsKey($o.Param) -and [Environment]::GetEnvironmentVariable($o.Env)) {
+          Write-Verbose "Get-CdfConfigService: $($o.Param) from `$env:$($o.Env) override = '$($o.Value)' (cdf-config ServiceDefaults.$($o.Param) not applied)"
+        }
+      }
 
       # Get service configuration from infra config file
       $CdfService = Get-InfraServiceConfig `


### PR DESCRIPTION
Restores the intended precedence **explicit `-ServiceName` > `$env:CDF_SERVICE_NAME` > cdf-config `ServiceDefaults`** in `Get-CdfConfig` and `Get-CdfConfigService`.

Fixes #76

## Root cause
Both cmdlets resolved `Service{Name,Group,Type,Template}` via `$MyInvocation.BoundParameters`, which contains only **explicitly passed** args. A value arriving through the parameter default `[string] $ServiceName = $env:CDF_SERVICE_NAME` is *not* "bound", so a deploy that sets `CDF_SERVICE_NAME` in the environment and calls `Get-CdfConfig` **without** `-ServiceName` had the env override silently discarded — `ServiceDefaults` won. That broke deploying the same service implementation under different runtime names via the env override. (Introduced `54f5bcff`, over-correcting the original "explicit lost to env" bug.)

## Fix
Drop the `BoundParameters` test; keep a truthiness check on the variable (already explicit-or-env via the default):
```powershell
$ServiceName = $ServiceName ? $ServiceName : $svcConfig.ServiceDefaults.ServiceName
```
**`? :` not `??`** — the `[string]` default is `''` (not `$null`) when the env var is unset, so `??` would not fall through. Applied to all four fields in `func_Get-Config.ps1` and `func_Get-ConfigService.ps1`.

## Also
- **`Write-Verbose`** when a `CDF_SERVICE_*` env override is in effect, so an unintended one is easy to spot.
- **`$PSScriptRoot`** schema ref in `Get-ConfigService` (was the module-only `ModuleBase`) so the precedence is dot-source testable — same testability fix already applied to `Get-Config` in #71.

## Tests (9 new)
- `func_Get-ConfigService.Tests.ps1` (6): explicit/env/ServiceDefaults precedence, no cross-field bleed, the Verbose note is/ isn't emitted.
- `func_Get-Config.Tests.ps1` (3): end-to-end **chain** — real `Get-Config` → real `Get-ConfigService` (platform/app/domain stubbed, deployed domain) asserting the env override reaches `Service.Config.serviceName`.

Full suite **67/67**; changed files analyzer-clean.

## Operational note
Env-precedence means a **single-process** multi-service deploy loop must set/clear `CDF_SERVICE_*` per iteration (CI's one-job-per-service is unaffected). Worth a docs line.