### PR TITLE
feat: complete package deploy-from-cache (Install-CdfPackage → Deploy-CdfTemplate*)

### DIFF
--- a/CDFModule/Private/func_CdfRegistry.ps1
+++ b/CDFModule/Private/func_CdfRegistry.ps1
@@ -244,20 +244,20 @@ Function Resolve-CdfRegistryConfig {
     # 1. Project-level
     $projectFile = Join-Path $ProjectDir ".cdf/registries/$Name.json"
     if (Test-Path $projectFile) {
-        Write-Verbose "Resolved registry '$Name' from project: $projectFile"
+        Write-Host "CDF: registry '$Name' resolved from project file: $projectFile"
         return Get-Content -Raw $projectFile | ConvertFrom-Json -AsHashtable
     }
 
     # 2. User-level
     $userFile = Join-Path $HOME ".cdf/registries/$Name.json"
     if (Test-Path $userFile) {
-        Write-Verbose "Resolved registry '$Name' from user: $userFile"
+        Write-Host "CDF: registry '$Name' resolved from USER file: $userFile (this overrides any repo inline '$Name' — remove/override it if that is unexpected)"
         return Get-Content -Raw $userFile | ConvertFrom-Json -AsHashtable
     }
 
     # 3. Inline from manifest
     if ($InlineRegistries -and $InlineRegistries.ContainsKey($Name)) {
-        Write-Verbose "Resolved registry '$Name' from inline manifest"
+        Write-Host "CDF: registry '$Name' resolved from inline cdf-packages.json"
         return $InlineRegistries[$Name]
     }
 

--- a/CDFModule/Private/func_New-CdfPackageDeployView.Tests.ps1
+++ b/CDFModule/Private/func_New-CdfPackageDeployView.Tests.ps1
@@ -1,0 +1,67 @@
+BeforeAll {
+    $testFolder = Split-Path -Parent $PSCommandPath
+    . (Join-Path $testFolder 'func_New-CdfPackageDeployView.ps1')
+}
+
+Describe 'New-CdfPackageDeployView' {
+
+    BeforeEach {
+        $script:cacheRoot = Join-Path $TestDrive 'cache'
+        # Template package: templates/<endpoint>/<scope>/<name>/<version>/<release>/...
+        $tDir = Join-Path $script:cacheRoot 'templates/ghcr.io/org/platform/blank/v1/0.1.0'
+        New-Item -ItemType Directory -Path $tDir -Force | Out-Null
+        'targetScope = ''subscription''' | Set-Content -Path (Join-Path $tDir 'platform.bicep')
+        # Config package: configs/<endpoint>/<configKey>/<release>/{cdf-runtime.json, platform/...}
+        $cDir = Join-Path $script:cacheRoot 'configs/ghcr.io/org/axldb01/0.1.0'
+        New-Item -ItemType Directory -Path (Join-Path $cDir 'platform') -Force | Out-Null
+        @{ platformId = 'axldb'; instanceId = '01'; release = '0.1.0' } | ConvertTo-Json | Set-Content -Path (Join-Path $cDir 'cdf-runtime.json')
+        '{}' | Set-Content -Path (Join-Path $cDir 'platform/environments.json')
+    }
+
+    It 'maps templates to <scope>/<name>/<version> and configs to <platformId>/<instanceId>' {
+        $view = New-CdfPackageDeployView -CacheRoot $script:cacheRoot `
+            -Templates @(@{ Endpoint = 'ghcr.io/org'; Path = 'platform/blank/v1'; Release = '0.1.0' }) `
+            -Configs @(@{ Endpoint = 'ghcr.io/org'; Path = 'axldb01'; Release = '0.1.0' })
+
+        # Template resolves at $CDF_INFRA_TEMPLATES_PATH/<scope>/<name>/<version>/...
+        Test-Path (Join-Path $view.TemplatesPath 'platform/blank/v1/platform.bicep') | Should -BeTrue
+        # Config resolves at $CDF_INFRA_SOURCE_PATH/<platformId>/<instanceId>/... (the loader shape)
+        Test-Path (Join-Path $view.SourcePath 'axldb/01/platform/environments.json') | Should -BeTrue
+        $view.TemplatesPath | Should -Match 'templates$'
+        $view.SourcePath | Should -Match 'source$'
+    }
+
+    It 'derives <platformId>/<instanceId> from the packed cdf-runtime.json, not the configKey' {
+        # configKey 'axldb01' is ambiguous to split; the runtime manifest is authoritative.
+        $view = New-CdfPackageDeployView -CacheRoot $script:cacheRoot `
+            -Configs @(@{ Endpoint = 'ghcr.io/org'; Path = 'axldb01'; Release = '0.1.0' })
+        Test-Path (Join-Path $view.SourcePath 'axldb/01') | Should -BeTrue
+    }
+
+    It 'includes all configs (not just the first)' {
+        $c2 = Join-Path $script:cacheRoot 'configs/ghcr.io/org/axcdb01/0.1.0'
+        New-Item -ItemType Directory -Path $c2 -Force | Out-Null
+        @{ platformId = 'axcdb'; instanceId = '01' } | ConvertTo-Json | Set-Content -Path (Join-Path $c2 'cdf-runtime.json')
+        $view = New-CdfPackageDeployView -CacheRoot $script:cacheRoot -Configs @(
+            @{ Endpoint = 'ghcr.io/org'; Path = 'axldb01'; Release = '0.1.0' },
+            @{ Endpoint = 'ghcr.io/org'; Path = 'axcdb01'; Release = '0.1.0' }
+        )
+        Test-Path (Join-Path $view.SourcePath 'axldb/01') | Should -BeTrue
+        Test-Path (Join-Path $view.SourcePath 'axcdb/01') | Should -BeTrue
+    }
+
+    It 'is deterministic for the same package set' {
+        $a = New-CdfPackageDeployView -CacheRoot $script:cacheRoot -Configs @(@{ Endpoint = 'ghcr.io/org'; Path = 'axldb01'; Release = '0.1.0' })
+        $b = New-CdfPackageDeployView -CacheRoot $script:cacheRoot -Configs @(@{ Endpoint = 'ghcr.io/org'; Path = 'axldb01'; Release = '0.1.0' })
+        $a.ViewRoot | Should -BeExactly $b.ViewRoot
+    }
+
+    It 'warns and skips a config with no cdf-runtime.json' {
+        $bad = Join-Path $script:cacheRoot 'configs/ghcr.io/org/noruntime01/0.1.0'
+        New-Item -ItemType Directory -Path $bad -Force | Out-Null
+        '{}' | Set-Content -Path (Join-Path $bad 'platform.json')
+        $view = New-CdfPackageDeployView -CacheRoot $script:cacheRoot `
+            -Configs @(@{ Endpoint = 'ghcr.io/org'; Path = 'noruntime01'; Release = '0.1.0' }) -WarningAction SilentlyContinue
+        @(Get-ChildItem -Path $view.SourcePath -ErrorAction SilentlyContinue).Count | Should -Be 0
+    }
+}

--- a/CDFModule/Private/func_New-CdfPackageDeployView.ps1
+++ b/CDFModule/Private/func_New-CdfPackageDeployView.ps1
@@ -1,0 +1,90 @@
+Function New-CdfPackageDeployView {
+    <#
+    .SYNOPSIS
+    Materializes a classic-layout deploy view of installed packages and returns its paths.
+
+    .DESCRIPTION
+    Internal helper for Install-CdfPackage. The package cache stores
+    {templates|configs}/<endpoint>/<path>/<release>/, which does not match what the
+    Get-Cdf*Config* / Deploy-CdfTemplate* loaders expect. This builds a real-directory view
+    (copy — NOT symlink: the loaders Resolve-Path-canonicalize, which would defeat a symlink)
+    so the existing loaders work from the cache unchanged:
+
+      <view>/templates/<scope>/<name>/<version>/   (contents of each template release dir)
+      <view>/source/<platformId>/<instanceId>/      (contents of each config release dir;
+                                                      ids read from the config's packed cdf-runtime.json)
+
+    Callers set CDF_INFRA_TEMPLATES_PATH = .TemplatesPath and CDF_INFRA_SOURCE_PATH = .SourcePath.
+
+    .PARAMETER Templates
+    Installed template descriptors: @{ Endpoint; Path; Release } where Path = '<scope>/<name>/<version>'.
+
+    .PARAMETER Configs
+    Installed config descriptors: @{ Endpoint; Path; Release } where Path = '<configKey>'.
+
+    .OUTPUTS
+    [ordered] @{ TemplatesPath; SourcePath; ViewRoot }
+
+    .NOTES
+    Internal helper; not exported.
+    #>
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory = $false)]
+        [array]$Templates = @(),
+        [Parameter(Mandatory = $false)]
+        [array]$Configs = @(),
+        [Parameter(Mandatory = $false)]
+        [string]$CacheRoot = (Get-CdfPackageCacheRoot)
+    )
+
+    # Deterministic per-resolution view: the same package set hashes to the same view root,
+    # so a re-install of the same resolution reuses it and a different resolution gets its own.
+    $refs = @(
+        $Templates | ForEach-Object { "t:$($_.Endpoint)/$($_.Path)@$($_.Release)" }
+        $Configs | ForEach-Object { "c:$($_.Endpoint)/$($_.Path)@$($_.Release)" }
+    ) | Sort-Object
+    $hashBytes = [System.Security.Cryptography.SHA1]::HashData([System.Text.Encoding]::UTF8.GetBytes(($refs -join ';')))
+    $hash = (($hashBytes | ForEach-Object { $_.ToString('x2') }) -join '').Substring(0, 12)
+
+    $viewRoot = Join-Path -Path $CacheRoot -ChildPath ".views/$hash"
+    $templatesView = Join-Path -Path $viewRoot -ChildPath 'templates'
+    $sourceView = Join-Path -Path $viewRoot -ChildPath 'source'
+
+    # Rebuild fresh — dirs are small and the path is content-addressed by the hash.
+    if (Test-Path $viewRoot) { Remove-Item -Path $viewRoot -Recurse -Force }
+    New-Item -ItemType Directory -Path $templatesView -Force | Out-Null
+    New-Item -ItemType Directory -Path $sourceView -Force | Out-Null
+
+    foreach ($t in $Templates) {
+        $src = Join-Path -Path $CacheRoot -ChildPath "templates/$($t.Endpoint)/$($t.Path)/$($t.Release)"
+        if (-not (Test-Path $src)) { Write-Warning "Template package not cached, skipping view mapping: $src"; continue }
+        $dst = Join-Path -Path $templatesView -ChildPath $t.Path   # <scope>/<name>/<version>
+        New-Item -ItemType Directory -Path $dst -Force | Out-Null
+        Copy-Item -Path (Join-Path $src '*') -Destination $dst -Recurse -Force
+    }
+
+    foreach ($c in $Configs) {
+        $src = Join-Path -Path $CacheRoot -ChildPath "configs/$($c.Endpoint)/$($c.Path)/$($c.Release)"
+        if (-not (Test-Path $src)) { Write-Warning "Config package not cached, skipping view mapping: $src"; continue }
+        $runtimePath = Join-Path -Path $src -ChildPath 'cdf-runtime.json'
+        if (-not (Test-Path $runtimePath)) {
+            Write-Warning "Config package '$($c.Path)' has no cdf-runtime.json; cannot place it in the deploy view."
+            continue
+        }
+        $runtime = Get-Content -Raw $runtimePath | ConvertFrom-Json
+        if (-not $runtime.platformId -or -not $runtime.instanceId) {
+            Write-Warning "Config package '$($c.Path)' cdf-runtime.json lacks platformId/instanceId; cannot place it in the deploy view."
+            continue
+        }
+        $dst = Join-Path -Path $sourceView -ChildPath "$($runtime.platformId)/$($runtime.instanceId)"
+        New-Item -ItemType Directory -Path $dst -Force | Out-Null
+        Copy-Item -Path (Join-Path $src '*') -Destination $dst -Recurse -Force
+    }
+
+    return [ordered]@{
+        TemplatesPath = $templatesView
+        SourcePath    = $sourceView
+        ViewRoot      = $viewRoot
+    }
+}

--- a/CDFModule/Public/func_Install-Package.ps1
+++ b/CDFModule/Public/func_Install-Package.ps1
@@ -88,9 +88,11 @@ Function Install-Package {
     }
 
     $manifest = Get-Content -Raw $ManifestPath | ConvertFrom-Json -AsHashtable
+    # 'settings' is the canonical key for config-instance packages (the org reference manifest uses it);
+    # accept 'configs' as a back-compat alias so neither is silently skipped.
+    if (-not $manifest.configs -and $manifest.settings) { $manifest.configs = $manifest.settings }
     $inlineRegistries = $manifest.registries
     $providers = @{}
-    $defaultEndpoint = $null
 
     # Collect all registry names referenced by packages
     $referencedRegistries = @('default')
@@ -112,9 +114,6 @@ Function Install-Package {
     foreach ($regName in $referencedRegistries) {
         $regConfig = Resolve-CdfRegistryConfig -Name $regName -InlineRegistries $inlineRegistries
         $providers[$regName] = New-CdfRegistryProvider $regConfig
-        if ($regName -eq 'default') {
-            $defaultEndpoint = $regConfig.endpoint
-        }
     }
 
     # Login to all registries
@@ -204,20 +203,20 @@ Function Install-Package {
         }
     }
 
-    # Set environment variables for backwards compatibility
-    if ($installedTemplates.Count -gt 0 -and $defaultEndpoint) {
-        $cacheRoot = Get-CdfPackageCacheRoot
-        $templatesPath = Join-Path $cacheRoot "templates/$defaultEndpoint"
-        $env:CDF_INFRA_TEMPLATES_PATH = $templatesPath
-        Write-Host "Set CDF_INFRA_TEMPLATES_PATH=$templatesPath"
-    }
-
-    if ($installedConfigs.Count -gt 0) {
-        $firstConfig = $installedConfigs[0]
-        $cacheRoot = Get-CdfPackageCacheRoot
-        $configPath = Join-Path $cacheRoot "configs/$($firstConfig.Endpoint)/$($firstConfig.Path)/$($firstConfig.Release)"
-        $env:CDF_INFRA_SOURCE_PATH = $configPath
-        Write-Host "Set CDF_INFRA_SOURCE_PATH=$configPath"
+    # Materialise a classic-layout deploy view so the existing Get-Cdf*/Deploy-Cdf* loaders work
+    # from the cache. The cache stores {templates|configs}/<endpoint>/<path>/<release>/, which the
+    # loaders don't understand (extra <release> level for templates; flattened instance for configs);
+    # the view maps each to <scope>/<name>/<version>/ and <platformId>/<instanceId>/.
+    if ($installedTemplates.Count -gt 0 -or $installedConfigs.Count -gt 0) {
+        $view = New-CdfPackageDeployView -Templates $installedTemplates -Configs $installedConfigs
+        if ($installedTemplates.Count -gt 0) {
+            $env:CDF_INFRA_TEMPLATES_PATH = $view.TemplatesPath
+            Write-Host "Set CDF_INFRA_TEMPLATES_PATH=$($view.TemplatesPath)"
+        }
+        if ($installedConfigs.Count -gt 0) {
+            $env:CDF_INFRA_SOURCE_PATH = $view.SourcePath
+            Write-Host "Set CDF_INFRA_SOURCE_PATH=$($view.SourcePath)"
+        }
     }
 
     # Summary

--- a/CDFModule/Resources/Schemas/cdf-packages.schema.json
+++ b/CDFModule/Resources/Schemas/cdf-packages.schema.json
@@ -25,7 +25,14 @@
       "additionalProperties": {
         "type": "string"
       },
-      "description": "Config package references keyed by '<platformId><instanceId>' or '<platformId><instanceId>@<registry>'. Values are semver ranges."
+      "description": "Config-instance package references keyed by '<platformId><instanceId>' or '<platformId><instanceId>@<registry>'. Values are semver ranges. Back-compat alias for 'settings'."
+    },
+    "settings": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      },
+      "description": "Canonical key for config-instance (settings) package references; same shape as 'configs'. Keyed by '<platformId><instanceId>' or '<platformId><instanceId>@<registry>', values are semver ranges."
     }
   },
   "$defs": {

--- a/docs/proposals/install-cdfpackage-deploy-view.md
+++ b/docs/proposals/install-cdfpackage-deploy-view.md
@@ -1,0 +1,145 @@
+# Proposal: complete the package deploy-from-cache path (`Install-CdfPackage` → `Deploy-CdfTemplate*`)
+
+**Status:** Draft for the CDFModule build team · **Affects:** CDFModule ≥ 1.2.22 (package commands:
+`Publish-CdfTemplate`, `Publish-CdfConfig`, `Install-CdfPackage`, `Get-CdfPackage`)
+**Author:** Andreas Stenlund · **Discovered in:** `axl-it-ops/axl-lz-db` (db01 DBaaS landing zone), first real adopter of the OCI publish/install flow.
+
+## 1. Summary
+
+The new package commands **publish and install correctly**, but the **deploy-from-cache path is
+incomplete**: after `Install-CdfPackage`, the environment variables it sets (`CDF_INFRA_TEMPLATES_PATH`,
+`CDF_INFRA_SOURCE_PATH`) point at cache directories whose **layout does not match what the existing
+`Get-Cdf*Config*` / `Deploy-CdfTemplate*` loaders expect**. As a result, a clean
+`Install-CdfPackage` → `Deploy-CdfTemplatePlatform` fails.
+
+**Ask:** make `Install-CdfPackage` materialise a **classic-layout deploy view** in the cache and point
+`CDF_INFRA_*` at *that*, so the existing deploy cmdlets work unchanged. (Alternatives in §6.)
+
+## 2. Context — the intended workflow
+
+The package model replaces "point `CDF_INFRA_*` at the working tree / a release zip" with:
+
+```
+Publish-CdfTemplate / Publish-CdfConfig   # CI: pack template/config dirs → OCI artifacts in a registry
+Install-CdfPackage                         # local/CI: pull declared packages to ~/.cdf, set CDF_INFRA_*
+Get-CdfConfigPlatform | Deploy-CdfTemplatePlatform   # deploy from the cached release
+```
+
+This is the workflow we want for landing-zone deploys (released, versioned templates + configs, not the
+working tree). The publish + install halves work; the deploy half does not.
+
+## 3. What works
+
+- `Publish-CdfTemplate` / `Publish-CdfConfig` → `oras push` to `ghcr.io/<org>` (OCI provider,
+  `GITHUB_TOKEN`). Verified: 5 packages published to `ghcr.io/axl-it-ops:0.1.0`.
+- `Install-CdfPackage` reads `cdf-packages.json`, resolves semver ranges, `oras pull`s to the cache,
+  and `Test-Dependency` passes.
+- Registry resolution layering (`.cdf/registries/<name>.json` project → user → inline) works — note it
+  means a **personal `~/.cdf/registries/default.json` silently overrides** a repo's inline `default`
+  (we hit this; a project-level `.cdf/registries/default.json` is the fix, but it's a sharp edge worth
+  documenting).
+
+## 4. Reproduction
+
+```pwsh
+# Given a repo with cdf-template.json/cdf-runtime.json manifests + cdf-packages.json (default → ghcr.io/axl-it-ops)
+$env:GITHUB_TOKEN = gh auth token
+Install-CdfPackage          # downloads to ~/.cdf, sets CDF_INFRA_TEMPLATES_PATH + CDF_INFRA_SOURCE_PATH
+$env:CDF_PLATFORM_ID='axldb'; $env:CDF_PLATFORM_INSTANCE='01'; $env:CDF_PLATFORM_ENV_ID='axl-dev'; $env:CDF_REGION='swedencentral'
+Get-CdfConfigPlatform | Deploy-CdfTemplatePlatform
+```
+
+Result:
+
+```
+Cannot find path '…/.cdf/packages/configs/ghcr.io/axl-it-ops/axldb01/0.1.0/axldb/01/platform/environments.json'
+because it does not exist.
+```
+
+## 5. Root cause — cache layout vs. classic loader layout
+
+`Install-CdfPackage` sets (see `func_Install-Package.ps1`, the block commented *"Set environment
+variables for backwards compatibility"*):
+
+- `CDF_INFRA_TEMPLATES_PATH = <cacheRoot>/templates/<endpoint>`
+- `CDF_INFRA_SOURCE_PATH    = <cacheRoot>/configs/<endpoint>/<configPath>/<release>`
+
+The cache stores (see `func_CdfPackageCache.ps1`): `~/.cdf/packages/{templates|configs}/<endpoint>/<path>/<release>/…`
+
+But the deploy loaders resolve:
+
+| Loader resolves | Cache actually provides | Mismatch |
+|---|---|---|
+| `$CDF_INFRA_TEMPLATES_PATH/<scope>/<name>/<version>/` | `…/<endpoint>/<scope>/<name>/<version>/`**`<release>`**`/` | extra `/<release>/` level |
+| `$CDF_INFRA_SOURCE_PATH/<platformId>/<instanceId>/…` | `…/<endpoint>/`**`<configKey>/<release>`**`/<flattened-instance-contents>` | config is flattened to the instance contents; the loader re-appends `<platformId>/<instanceId>` → double-nest / not found |
+
+So the env-var bridge points "one level too high" for templates and at the flattened-instance dir for
+configs, neither of which the loaders understand.
+
+**Reconstruction also exposes a second issue.** Building a symlinked classic-layout view
+(`<view>/<scope>/<name>/<version>` → release dir; `<view>/<platformId>/<instanceId>` → config release
+dir) gets *past* the path error, but `Get-CdfConfigPlatform` then returns a **partial config**
+(`templateName` / `region` empty) and `Deploy-CdfTemplatePlatform` fails with *"Cannot bind argument to
+parameter 'Path' because it is null"*. Cause: the loader `Resolve-Path`s the symlink back to the flat
+cache dir and re-appends `<platformId>/<instanceId>`, so a **symlinked** view isn't enough — the view
+must be real directories (copies/junctions) or the loaders must stop canonicalising.
+
+## 6. Proposed solution
+
+**Primary — `Install-CdfPackage` materialises a real classic-layout deploy view and points `CDF_INFRA_*` at it.**
+
+After downloading packages, build a per-install view under the cache, e.g.:
+
+```
+~/.cdf/packages/.views/<hash>/templates/<scope>/<name>/<version>/   → contents of <templates>/<endpoint>/<scope>/<name>/<version>/<resolved-release>/
+~/.cdf/packages/.views/<hash>/source/<platformId>/<instanceId>/     → contents of <configs>/<endpoint>/<configKey>/<resolved-release>/
+```
+
+then set:
+
+```
+CDF_INFRA_TEMPLATES_PATH = ~/.cdf/packages/.views/<hash>/templates
+CDF_INFRA_SOURCE_PATH    = ~/.cdf/packages/.views/<hash>/source
+```
+
+- Use **real directories** — directory junctions/hardlinks where supported, else copy. Avoid symlinks
+  (loaders `Resolve-Path`-canonicalise them, defeating the view — see §5).
+- Split `<configKey>` → `<platformId>/<instanceId>` using the same rule `Publish-CdfConfig` used to
+  build it (`platformId + instanceId`), or carry `platformId`/`instanceId` in the cache index so the
+  view builder doesn't have to re-parse.
+- Cross-platform: Windows directory junctions (`New-Item -ItemType Junction`) / `mklink /J`; macOS/Linux
+  bind-style isn't available without root, so **copy** is the safe default (template/config dirs are small).
+
+This keeps `Get-Cdf*`/`Deploy-Cdf*` **unchanged** — the smallest blast radius.
+
+**Alternatives considered**
+
+1. *Make the loaders package/cache-aware* (descend into the resolved release; map `<platformId>/<instanceId>` → `<configKey>/<release>`). More invasive, touches the hot deploy path, higher regression risk.
+2. *Change the cache layout to be deploy-shaped* (drop the `<release>` leaf, nest configs under `<platformId>/<instanceId>`). Breaks multi-release caching and `Get-CdfPackage`/index semantics.
+
+The view approach (primary) is preferred: localised to `Install-CdfPackage`, leaves cache + loaders intact.
+
+## 7. Acceptance criteria
+
+- `Install-CdfPackage` then `Get-CdfConfigPlatform | Deploy-CdfTemplatePlatform` (and `…Application` /
+  `…Domain`) **succeeds from the cache**, with a fully-populated config (`templateName`, `templateVersion`,
+  `region`, …) — no working-tree paths set by the user.
+- Works for multiple cached releases of the same package (view reflects the resolved range).
+- Works cross-platform (Linux CI runner + macOS/Windows workstation).
+- `README` quick-start `Install-CdfPackage` → deploy works verbatim.
+
+## 8. Notes
+
+- **Registry override sharp edge** (§3): consider logging which registry source won
+  (`project | user | inline`) at `Install`/`Publish` time, so a personal `~/.cdf/registries/default.json`
+  silently redirecting an org repo is visible. We worked around it with a committed project-level
+  `.cdf/registries/default.json`.
+- **`cdf-packages.json` `configs` vs `settings`**: the installed/fork `Install-Package` reads
+  `$manifest.configs`, but the `cdf-infra-main` reference manifest uses a `settings` key — these don't
+  match (configs silently not installed if `settings` is used). Align the schema + the reference.
+
+## Appendix — environment
+
+- CDFModule 1.2.22(-pre); `oras` 1.3.2; OCI provider → `ghcr.io/axl-it-ops`, `GITHUB_TOKEN`.
+- Worked example: `axl-it-ops/axl-lz-db`, packages `cdf/templates/{platform/dataplatform,application/mssql,domain/mssql}/v1net:0.1.0` and `cdf/configs/{axldb01,axcdb01}:0.1.0`.
+- Cache root `~/.cdf/packages`; layout `{templates|configs}/<endpoint>/<path>/<release>/`.


### PR DESCRIPTION
Makes a clean `Install-CdfPackage` → `Deploy-CdfTemplatePlatform` work from the cache. Full diagnosis in `docs/proposals/install-cdfpackage-deploy-view.md` (verified against code).

Fixes #78

## The problem
After `Install-CdfPackage`, `CDF_INFRA_*` pointed at cache dirs whose layout the deploy loaders don't understand: templates had an extra `/<release>/` level, configs were flattened (loader re-appended `<platformId>/<instanceId>` → not found). Only the **first** config's path was exported.

## Fix
- **`New-CdfPackageDeployView`** (Private) materialises a real classic-layout view and `Install-CdfPackage` points `CDF_INFRA_*` at it:
  - `<view>/templates/<scope>/<name>/<version>/` (from each template release dir)
  - `<view>/source/<platformId>/<instanceId>/` — ids read from each config's packed `cdf-runtime.json` (**option a**; `Publish-Config` already records them), covering **all** configs.
  - **Copy, not symlink** (the loaders `Resolve-Path`-canonicalise, which defeats symlinks).
  - Deterministic per-resolution view (`.views/<hash>`), so re-installs reuse it.
- **`settings`/`configs` alias:** `Install-CdfPackage` now treats `settings` as the canonical config-package key (the org reference manifest uses it — was silently skipped) with `configs` as a back-compat alias; schema updated. Foreshadows the `CdfSetting`/`CdfRuntimeConfig` split.
- **Registry-source logging:** surface which source resolved (project | user | inline) so a personal `~/.cdf/registries/default.json` silently overriding an org repo is visible.

Leaves the deploy loaders and cache index untouched (smallest blast radius — the proposal's primary option).

## Tests
`func_New-CdfPackageDeployView.Tests.ps1` (6): template/config layout mapping, `platformId/instanceId` from `cdf-runtime.json` (not the ambiguous configKey), all-configs, determinism, graceful skip on missing `cdf-runtime.json`. Full suite **75/75**; changed files analyzer-clean.

## Follow-ups (not here)
The *full* `configs`→`settings` rename (cache `configs/` dir, `Publish-CdfConfig`, `Get-CdfPackage`, docs) belongs with the Phase-2 `CdfSetting`/`CdfRuntimeConfig` work. Junction/hardlink optimisation over copy is a later nicety.