### PR TITLE
fix: route a literal -Registry endpoint by host (GHCR → oci, ACR → acr)

### DIFF
--- a/CDFModule/Private/func_CdfRegistry.ps1
+++ b/CDFModule/Private/func_CdfRegistry.ps1
@@ -203,6 +203,19 @@ class CdfOciRegistryProvider : CdfRegistryProvider {
     }
 }
 
+# Infer a registry config from a literal endpoint passed via -Registry (the convenience path, distinct
+# from a named registry). Route by host so a GHCR/OCI endpoint is NOT mis-typed as ACR — which would try
+# an Azure token (Get-AzAccessToken) and fail against GitHub. *.azurecr.io -> acr; ghcr.io /
+# *.pkg.github.com -> oci (token read from CDF_REGISTRY_TOKEN); anything else -> acr for backwards compat.
+Function Get-CdfRegistryConfigFromEndpoint {
+    [CmdletBinding()]
+    Param([Parameter(Mandatory = $true)][string]$Endpoint)
+    if ($Endpoint -match '(?i)^ghcr\.io([/:]|$)' -or $Endpoint -match '(?i)\.pkg\.github\.com') {
+        return @{ type = 'oci'; endpoint = $Endpoint; username = 'cdf'; passwordEnvVar = 'CDF_REGISTRY_TOKEN' }
+    }
+    return @{ type = 'acr'; endpoint = $Endpoint }
+}
+
 # Factory function to create a registry provider from a registry config entry
 Function New-CdfRegistryProvider {
     [CmdletBinding()]

--- a/CDFModule/Public/func_Install-Package.ps1
+++ b/CDFModule/Public/func_Install-Package.ps1
@@ -62,7 +62,8 @@ Function Install-Package {
             $inlineRegistries = $manifest.registries
         }
         if ($Registry -and $Registry -match '\.') {
-            $regConfig = @{ type = 'acr'; endpoint = $Registry }
+            # Literal endpoint — route by host (GHCR -> oci, ACR -> acr) so GHCR isn't mis-typed as ACR.
+            $regConfig = Get-CdfRegistryConfigFromEndpoint -Endpoint $Registry
         }
         else {
             $regName = if ($Registry) { $Registry } else { 'default' }

--- a/CDFModule/Public/func_Publish-Config.ps1
+++ b/CDFModule/Public/func_Publish-Config.ps1
@@ -62,7 +62,8 @@ Function Publish-Config {
         $inlineRegistries = $pkgManifest.registries
     }
     if ($Registry -and $Registry -match '\.') {
-        $regConfig = @{ type = 'acr'; endpoint = $Registry }
+        # Literal endpoint — route by host (GHCR -> oci, ACR -> acr) so GHCR isn't mis-typed as ACR.
+        $regConfig = Get-CdfRegistryConfigFromEndpoint -Endpoint $Registry
     }
     else {
         $regName = if ($Registry) { $Registry } else { 'default' }

--- a/CDFModule/Public/func_Publish-Template.ps1
+++ b/CDFModule/Public/func_Publish-Template.ps1
@@ -61,8 +61,8 @@ Function Publish-Template {
         $inlineRegistries = $pkgManifest.registries
     }
     if ($Registry -and $Registry -match '\.') {
-        # Literal endpoint (e.g. ghcr.io/org or myacr.azurecr.io) — assume ACR for backwards compat
-        $regConfig = @{ type = 'acr'; endpoint = $Registry }
+        # Literal endpoint (e.g. ghcr.io/org or myacr.azurecr.io) — route by host (GHCR -> oci, ACR -> acr).
+        $regConfig = Get-CdfRegistryConfigFromEndpoint -Endpoint $Registry
     }
     else {
         $regName = if ($Registry) { $Registry } else { 'default' }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Registry endpoint routing: a literal `-Registry` endpoint is now typed by host (`Get-CdfRegistryConfigFromEndpoint`) — `ghcr.io` / `*.pkg.github.com` → `oci`, `*.azurecr.io` (and anything else, for back-compat) → `acr`. Previously any dotted endpoint was assumed ACR, so `Install-CdfPackage`/`Publish-Cdf*` against `ghcr.io/...` tried an Azure token (`Get-AzAccessToken`) and failed. Applies to `Publish-CdfTemplate`, `Publish-CdfConfig`, `Install-CdfPackage`
 - Service name precedence restored to explicit `-ServiceName` > `$env:CDF_SERVICE_NAME` > cdf-config `ServiceDefaults` — a `BoundParameters` check was discarding the env override (PR #77, completes #76)
 - `Get-AzAccessToken` SecureString token handled for Az 14.0+/16.0: bearer-header and registry-login sites convert via a version-tolerant helper (was emitting `System.Security.SecureString`) (PR #75, #74)
 - Module installs without `-AcceptLicense`: `RequireLicenseAcceptance` disabled (the Apache-2.0 license added in #22 is informational, not an acceptance gate)


### PR DESCRIPTION
A literal `-Registry` endpoint is now typed by host via `Get-CdfRegistryConfigFromEndpoint`: `ghcr.io` / `*.pkg.github.com` → `oci`, `*.azurecr.io` (and anything else, for back-compat) → `acr`. Previously any dotted endpoint was assumed ACR, so `Install-CdfPackage`/`Publish-Cdf*` against `ghcr.io/...` tried an Azure token (`Get-AzAccessToken`) and failed. Applies to `Publish-CdfTemplate`, `Publish-CdfConfig`, `Install-CdfPackage`.

Part of the package/registry line (#78/#79).