### PR TITLE
ci: pin Pester to 5.x (Pester 6 removed Assert-MockCalled)

### DIFF
--- a/.github/workflows/test-cdfmodule.yaml
+++ b/.github/workflows/test-cdfmodule.yaml
@@ -36,7 +36,8 @@ jobs:
 
       - name: Install Pester
         shell: pwsh
-        run: Install-Module Pester -MinimumVersion 5.5.0 -Force -Scope CurrentUser
+        # Pin to Pester 5.x: Pester 6 dropped the legacy Assert-MockCalled command the tests rely on.
+        run: Install-Module Pester -MinimumVersion 5.5.0 -MaximumVersion 5.999.999 -Force -Scope CurrentUser
 
       - name: Run Pester
         shell: pwsh


### PR DESCRIPTION
## Problem

Pester **6.0.0** was just published to the PowerShell Gallery. CI installs it with:

```
Install-Module Pester -MinimumVersion 5.5.0 -Force -Scope CurrentUser
```

With no upper bound, that now resolves to **6.0.0**, which **removed the legacy `Assert-MockCalled`** command that 8 test files rely on. Every Pester run on every PR fails with:

```
CommandNotFoundException: The 'Assert-MockCalled' command was found in the module 'Pester', but the module could not be loaded.
```

This is environmental — it hit **every** open PR identically (including docs-only changes), not caused by any single branch. Local runs stayed green because they use Pester 5.7.1.

## Fix

Cap the install at `5.999.999` to restore the previously-green Pester 5.x behaviour.

## Follow-up

Migrating the 8 test files from `Assert-MockCalled` to `Should -Invoke` (and auditing other Pester 6 breaking changes) is tracked separately so we can move to Pester 6 deliberately.