### PR TITLE
test: migrate to Should -Invoke, run CI on Pester 6

### DIFF
--- a/.github/workflows/test-cdfmodule.yaml
+++ b/.github/workflows/test-cdfmodule.yaml
@@ -36,8 +36,7 @@ jobs:
 
       - name: Install Pester
         shell: pwsh
-        # Pin to Pester 5.x: Pester 6 dropped the legacy Assert-MockCalled command the tests rely on.
-        run: Install-Module Pester -MinimumVersion 5.5.0 -MaximumVersion 5.999.999 -Force -Scope CurrentUser
+        run: Install-Module Pester -MinimumVersion 6.0.0 -Force -Scope CurrentUser
 
       - name: Run Pester
         shell: pwsh

--- a/.github/workflows/test-cdfmodule.yaml
+++ b/.github/workflows/test-cdfmodule.yaml
@@ -36,7 +36,8 @@ jobs:
 
       - name: Install Pester
         shell: pwsh
-        run: Install-Module Pester -MinimumVersion 5.5.0 -Force -Scope CurrentUser
+        # Pin to Pester 5.x: Pester 6 dropped the legacy Assert-MockCalled command the tests rely on.
+        run: Install-Module Pester -MinimumVersion 5.5.0 -MaximumVersion 5.999.999 -Force -Scope CurrentUser
 
       - name: Run Pester
         shell: pwsh

--- a/CDFModule/Public/func_ConvertTo-DotEnv.Tests.ps1
+++ b/CDFModule/Public/func_ConvertTo-DotEnv.Tests.ps1
@@ -34,7 +34,7 @@ TEST_TOKEN=This {TOKEN} should be 'word'
 '@
         } | Should -Not -Throw
 
-        Assert-MockCalled Write-Verbose -Scope It -Exactly -Times 0
+        Should -Invoke Write-Verbose -Scope It -Exactly -Times 0
     }
 
     It 'Should convert 2x2 name-value pair array' {
@@ -46,7 +46,7 @@ Name2=Value2
 '@
         } | Should -Not -Throw
 
-        Assert-MockCalled Write-Verbose -Scope It -Exactly -Times 1 -ParameterFilter { "Is array is determined to be key-value-pairs: YES" }
+        Should -Invoke Write-Verbose -Scope It -Exactly -Times 1 -ParameterFilter { "Is array is determined to be key-value-pairs: YES" }
     }
 
     It 'Should convert separate name and value column array' {
@@ -62,6 +62,6 @@ Name4=Value4
 '@
         } | Should -Not -Throw
 
-        Assert-MockCalled Write-Verbose -Scope It -Exactly -Times 1 -ParameterFilter { "Is array is determined to be key-value-pairs: NO" }
+        Should -Invoke Write-Verbose -Scope It -Exactly -Times 1 -ParameterFilter { "Is array is determined to be key-value-pairs: NO" }
     }
 }

--- a/CDFModule/Public/func_Export-DotEnv.Tests.ps1
+++ b/CDFModule/Public/func_Export-DotEnv.Tests.ps1
@@ -31,7 +31,7 @@ Describe 'Export-DotEnv' {
             Get-Content $repoRoot/output/Get-DotEnv.env | Should -Be "UNITTEST=RESULT"
         } | Should -Not -Throw
 
-        Assert-MockCalled Write-Verbose -Scope It -Exactly -Times 1 -ParameterFilter { $Message.StartsWith('Reading:') }
-        Assert-MockCalled Write-Verbose -Scope It -Exactly -Times 1 -ParameterFilter { $Message.StartsWith('Writing:') }
+        Should -Invoke Write-Verbose -Scope It -Exactly -Times 1 -ParameterFilter { $Message.StartsWith('Reading:') }
+        Should -Invoke Write-Verbose -Scope It -Exactly -Times 1 -ParameterFilter { $Message.StartsWith('Writing:') }
     }
 }

--- a/CDFModule/Public/func_Get-ConfigPlatform.Tests.ps1
+++ b/CDFModule/Public/func_Get-ConfigPlatform.Tests.ps1
@@ -27,36 +27,36 @@ Describe 'Get-ConfigPlatform' {
             Mock Write-Error {}
             Remove-Item Env:/CDF_REGION
             { Get-ConfigPlatform } | Should -Throw -ExpectedMessage 'Missing required CDF parameters'
-            Assert-MockCalled Write-Error -Scope It -Exactly -Times 1 -ParameterFilter { "Missing required CDF Parameter 'Region' or environment variable 'CDF_REGION'" }
+            Should -Invoke Write-Error -Scope It -Exactly -Times 1 -ParameterFilter { "Missing required CDF Parameter 'Region' or environment variable 'CDF_REGION'" }
         }
         It 'Should require PlatformId' {
             Mock Write-Error {}
             Remove-Item Env:/CDF_PLATFORM_ID
             { Get-ConfigPlatform } | Should -Throw -ExpectedMessage 'Missing required CDF parameters'
-            Assert-MockCalled Write-Error -Scope It -Exactly -Times 1 -ParameterFilter { "Missing required CDF Parameter 'PlatformId' or environment variable 'CDF_PLATFORM_ID'" }
+            Should -Invoke Write-Error -Scope It -Exactly -Times 1 -ParameterFilter { "Missing required CDF Parameter 'PlatformId' or environment variable 'CDF_PLATFORM_ID'" }
         }
         It 'Should require InstanceId' {
             Mock Write-Error {}
             Remove-Item Env:/CDF_PLATFORM_INSTANCE
             { Get-ConfigPlatform } | Should -Throw -ExpectedMessage 'Missing required CDF parameters'
-            Assert-MockCalled Write-Error -Scope It -Exactly -Times 1 -ParameterFilter { "Missing required CDF Parameter 'InstanceId' or environment variable 'CDF_PLATFORM_INSTANCE'" }
+            Should -Invoke Write-Error -Scope It -Exactly -Times 1 -ParameterFilter { "Missing required CDF Parameter 'InstanceId' or environment variable 'CDF_PLATFORM_INSTANCE'" }
         }
         It 'Should require EnvDefinitionId' {
             Mock Write-Error {}
             Remove-Item Env:/CDF_PLATFORM_ENV_ID
             { Get-ConfigPlatform } | Should -Throw -ExpectedMessage 'Missing required CDF parameters'
-            Assert-MockCalled Write-Error -Scope It -Exactly -Times 1 -ParameterFilter { "Missing required CDF Parameter 'EnvDefinitionId' or environment variable 'CDF_PLATFORM_ENV_ID'" }
+            Should -Invoke Write-Error -Scope It -Exactly -Times 1 -ParameterFilter { "Missing required CDF Parameter 'EnvDefinitionId' or environment variable 'CDF_PLATFORM_ENV_ID'" }
         }
         It 'Should not throw' {
             Mock Write-Error {}
             { Get-ConfigPlatform } | Should -Not -Throw
-            Assert-MockCalled Write-Error -Scope It -Exactly -Times 0
+            Should -Invoke Write-Error -Scope It -Exactly -Times 0
         }
         It 'Should return config' {
             Mock Write-Error {}
             $config = Get-ConfigPlatform
             $config | Should -Not -BeNullOrEmpty
-            Assert-MockCalled Write-Error -Scope It -Exactly -Times 0
+            Should -Invoke Write-Error -Scope It -Exactly -Times 0
         }
     }
 
@@ -71,27 +71,27 @@ Describe 'Get-ConfigPlatform' {
         It 'Should require Region' {
             Mock Write-Error {}
             { Get-ConfigPlatform -PlatformId test -InstanceId 01 -EnvDefinitionId local } | Should -Throw -ExpectedMessage 'Missing required CDF parameters'
-            Assert-MockCalled Write-Error -Scope It -Exactly -Times 1 -ParameterFilter { "Missing required CDF Parameter 'Region' or environment variable 'CDF_REGION'" }
+            Should -Invoke Write-Error -Scope It -Exactly -Times 1 -ParameterFilter { "Missing required CDF Parameter 'Region' or environment variable 'CDF_REGION'" }
         }
         It 'Should require PlatformId' {
             Mock Write-Error {}
             { Get-ConfigPlatform  -Region westeurope -InstanceId 01 -EnvDefinitionId local } | Should -Throw -ExpectedMessage 'Missing required CDF parameters'
-            Assert-MockCalled Write-Error -Scope It -Exactly -Times 1 -ParameterFilter { "Missing required CDF Parameter 'PlatformId' or environment variable 'CDF_PLATFORM_ID'" }
+            Should -Invoke Write-Error -Scope It -Exactly -Times 1 -ParameterFilter { "Missing required CDF Parameter 'PlatformId' or environment variable 'CDF_PLATFORM_ID'" }
         }
         It 'Should require PlatformInstance' {
             Mock Write-Error {}
             { Get-ConfigPlatform -Region westeurope -PlatformId test -EnvDefinitionId local } | Should -Throw -ExpectedMessage 'Missing required CDF parameters'
-            Assert-MockCalled Write-Error -Scope It -Exactly -Times 1 -ParameterFilter { "Missing required CDF Parameter 'PlatformInstance' or environment variable 'CDF_PLATFORM_INSTANCE'" }
+            Should -Invoke Write-Error -Scope It -Exactly -Times 1 -ParameterFilter { "Missing required CDF Parameter 'PlatformInstance' or environment variable 'CDF_PLATFORM_INSTANCE'" }
         }
         It 'Should require EnvDefinitionId' {
             Mock Write-Error {}
             { Get-ConfigPlatform -Region westeurope -PlatformId test -InstanceId 01 } | Should -Throw -ExpectedMessage 'Missing required CDF parameters'
-            Assert-MockCalled Write-Error -Scope It -Exactly -Times 1 -ParameterFilter { "Missing required CDF Parameter 'EnvDefinitionId' or environment variable 'CDF_PLATFORM_ENV_ID'" }
+            Should -Invoke Write-Error -Scope It -Exactly -Times 1 -ParameterFilter { "Missing required CDF Parameter 'EnvDefinitionId' or environment variable 'CDF_PLATFORM_ENV_ID'" }
         }
         It 'Should not throw' {
             Mock Write-Error {}
             { Get-ConfigPlatform -Region westeurope -PlatformId test -InstanceId 01 -EnvDefinitionId local } | Should -Not -Throw
-            Assert-MockCalled Write-Error -Scope It -Exactly -Times 0
+            Should -Invoke Write-Error -Scope It -Exactly -Times 0
         }
     }
 
@@ -129,7 +129,7 @@ Describe 'Get-ConfigPlatform' {
             $config.Platform.ResourceNames | Should -BeNullOrEmpty
             $config.Platform.NetworkConfig | Should -BeNullOrEmpty
             $config.Platform.AccessControl | Should -BeNullOrEmpty
-            Assert-MockCalled Write-Error -Scope It -Exactly -Times 0
+            Should -Invoke Write-Error -Scope It -Exactly -Times 0
         }
         It 'Should return correct config from deployment' {
             Mock Write-Error {}
@@ -148,9 +148,9 @@ Describe 'Get-ConfigPlatform' {
             $config.Platform.NetworkConfig | Should -BeNullOrEmpty
             $config.Platform.AccessControl | Should -BeNullOrEmpty
 
-            Assert-MockCalled Write-Error -Scope It -Exactly -Times 0
-            Assert-MockCalled Get-AzureContext -Scope It -Exactly -Times 1
-            Assert-MockCalled Get-AzSubscriptionDeployment -Scope It -Exactly -Times 1
+            Should -Invoke Write-Error -Scope It -Exactly -Times 0
+            Should -Invoke Get-AzureContext -Scope It -Exactly -Times 1
+            Should -Invoke Get-AzSubscriptionDeployment -Scope It -Exactly -Times 1
         }
 
         It 'Should write error configuration not complete' {
@@ -165,7 +165,7 @@ Describe 'Get-ConfigPlatform' {
             {
                 Get-ConfigPlatform -Deployed -Region westeurope -PlatformId test -InstanceId 01 -EnvDefinitionId local
             } | Should -Not -Throw
-            Assert-MockCalled Write-Error -Scope It -Exactly -Times 1
+            Should -Invoke Write-Error -Scope It -Exactly -Times 1
         }
 
         It 'Should return from file with warning on unsuccessful deployment status' {
@@ -181,8 +181,8 @@ Describe 'Get-ConfigPlatform' {
             {
                 Get-ConfigPlatform -Deployed -Region westeurope -PlatformId test -InstanceId 01 -EnvDefinitionId local
             } | Should -Not -Throw
-            Assert-MockCalled Write-Error -Scope It -Exactly -Times 0
-            Assert-MockCalled Write-Warning -Scope It -Exactly -Times 2
+            Should -Invoke Write-Error -Scope It -Exactly -Times 0
+            Should -Invoke Write-Warning -Scope It -Exactly -Times 2
         }
     }
 
@@ -239,7 +239,7 @@ Describe 'Get-ConfigPlatform' {
             $config.Platform.AccessControl.serviceBusRBAC | Should -BeNullOrEmpty
             $config.Platform.AccessControl.containerRegistryRBAC  | Should -BeNullOrEmpty
 
-            Assert-MockCalled Write-Error -Scope It -Exactly -Times 0
+            Should -Invoke Write-Error -Scope It -Exactly -Times 0
         }
 
         It 'Should return correct config from files for uat/westeurope' {
@@ -288,7 +288,7 @@ Describe 'Get-ConfigPlatform' {
             $config.Platform.AccessControl.serviceBusRBAC | Should -BeNullOrEmpty
             $config.Platform.AccessControl.containerRegistryRBAC  | Should -BeNullOrEmpty
 
-            Assert-MockCalled Write-Error -Scope It -Exactly -Times 0
+            Should -Invoke Write-Error -Scope It -Exactly -Times 0
         }
 
         It 'Should return correct config from deployment' {
@@ -312,10 +312,10 @@ Describe 'Get-ConfigPlatform' {
 
             # Write-Verbose "Loading enterprise spoke network configuration"
 
-            Assert-MockCalled Write-Verbose -Scope It -Exactly -Times 4
-            Assert-MockCalled Write-Error -Scope It -Exactly -Times 0
-            Assert-MockCalled Get-AzureContext -Scope It -Exactly -Times 1
-            Assert-MockCalled Get-AzSubscriptionDeployment -Scope It -Exactly -Times 1
+            Should -Invoke Write-Verbose -Scope It -Exactly -Times 4
+            Should -Invoke Write-Error -Scope It -Exactly -Times 0
+            Should -Invoke Get-AzureContext -Scope It -Exactly -Times 1
+            Should -Invoke Get-AzSubscriptionDeployment -Scope It -Exactly -Times 1
         }
     }
 }

--- a/CDFModule/Public/func_Get-DotEnv.Tests.ps1
+++ b/CDFModule/Public/func_Get-DotEnv.Tests.ps1
@@ -27,9 +27,9 @@ Describe 'Get-DotEnv' {
             $dotenv["TEST_TOKEN"] | Should -BeExactly "This {TOKEN} should be 'word'"
         } | Should -Not -Throw
 
-        Assert-MockCalled Write-Verbose -Scope It -Exactly -Times 8 -ParameterFilter { $Message.StartsWith('Adding:') }
-        Assert-MockCalled Write-Verbose -Scope It -Exactly -Times 1 -ParameterFilter { $Message.StartsWith('Skipping empty line:') }
-        Assert-MockCalled Write-Verbose -Scope It -Exactly -Times 1 -ParameterFilter { $Message.StartsWith('Skipping line without assigmment:') }
-        Assert-MockCalled Write-Verbose -Scope It -Exactly -Times 1 -ParameterFilter { $Message.StartsWith('Skipping line with comment:') }
+        Should -Invoke Write-Verbose -Scope It -Exactly -Times 8 -ParameterFilter { $Message.StartsWith('Adding:') }
+        Should -Invoke Write-Verbose -Scope It -Exactly -Times 1 -ParameterFilter { $Message.StartsWith('Skipping empty line:') }
+        Should -Invoke Write-Verbose -Scope It -Exactly -Times 1 -ParameterFilter { $Message.StartsWith('Skipping line without assigmment:') }
+        Should -Invoke Write-Verbose -Scope It -Exactly -Times 1 -ParameterFilter { $Message.StartsWith('Skipping line with comment:') }
     }
 }

--- a/CDFModule/Public/func_Get-TokenValues.Tests.ps1
+++ b/CDFModule/Public/func_Get-TokenValues.Tests.ps1
@@ -80,7 +80,7 @@ Describe 'Get-TokenValues' {
                 $tokens['Domain.Config.DomainName'] | Should -BeExactly $cdfConfig.Domain.Config.domainName
 
             } | Should -Not -Throw
-            Assert-MockCalled Get-AzContext -Scope It -Exactly -Times 1
+            Should -Invoke Get-AzContext -Scope It -Exactly -Times 1
         }
 
         It 'Should generate tokens for deployment config' {
@@ -154,7 +154,7 @@ Describe 'Get-TokenValues' {
                 $tokens['Service.Config.ServiceTemplate'] | Should -Not -BeNullOrEmpty
                 $tokens['Service.Config.ServiceTemplate'] | Should -Be -ExpectedValue  $cdfConfig.Service.Config.serviceTemplate
             } | Should -Not -Throw
-            Assert-MockCalled Get-AzContext -Scope It -Exactly -Times 1
+            Should -Invoke Get-AzContext -Scope It -Exactly -Times 1
         }
 
         It 'Should generate tokens for Old Apim ' {
@@ -224,7 +224,7 @@ Describe 'Get-TokenValues' {
                 $tokens['GITHUB_RUN_NUMBER'] | Should -BeExactly  'local'
 
             } | Should -Not -Throw
-            Assert-MockCalled Get-AzContext -Scope It -Exactly -Times 1
+            Should -Invoke Get-AzContext -Scope It -Exactly -Times 1
         }
 
         It 'Should generate tokens for aliases ' {
@@ -329,7 +329,7 @@ Describe 'Get-TokenValues' {
             $tokens['BuildRun'] | Should -BeExactly $env:GITHUB_RUN_ID
             #} | Should -Not -Throw
 
-            Assert-MockCalled Get-AzContext -Scope It -Exactly -Times 0
+            Should -Invoke Get-AzContext -Scope It -Exactly -Times 0
         }
     }
 
@@ -358,7 +358,7 @@ Describe 'Get-TokenValues' {
                 $tokens['BuildRun'] | Should -BeExactly $env:BUILD_BUILDNUMBER
             } | Should -Not -Throw
 
-            Assert-MockCalled Get-AzContext -Scope It -Exactly -Times 0
+            Should -Invoke Get-AzContext -Scope It -Exactly -Times 0
         }
 
     }

--- a/CDFModule/Public/func_New-ConfigApplication.Tests.ps1
+++ b/CDFModule/Public/func_New-ConfigApplication.Tests.ps1
@@ -37,7 +37,7 @@ Describe 'New-ConfigApplication' {
                 New-ConfigPlatform -TemplateName blank -TemplateVersion v1
                 Get-ConfigPlatform | New-ConfigApplication -TemplateName blank -TemplateVersion v1
             } | Should -Not -Throw
-            Assert-MockCalled Write-Error -Scope It -Exactly -Times 0
+            Should -Invoke Write-Error -Scope It -Exactly -Times 0
         }
         It 'Should return config' {
             Mock Write-Error {}
@@ -45,7 +45,7 @@ Describe 'New-ConfigApplication' {
             $config | Should -Not -BeNullOrEmpty
             $config.Platform | Should -Not -BeNullOrEmpty
             $config.Application | Should -Not -BeNullOrEmpty
-            Assert-MockCalled Write-Error -Scope It -Exactly -Times 0
+            Should -Invoke Write-Error -Scope It -Exactly -Times 0
         }
     }
 

--- a/CDFModule/Public/func_New-ConfigDomain.Tests.ps1
+++ b/CDFModule/Public/func_New-ConfigDomain.Tests.ps1
@@ -43,7 +43,7 @@ Describe 'New-ConfigDomain' {
             $cfgApplication = $cfgPlatform | Get-ConfigApplication
             $cfgApplication | New-ConfigDomain -TemplateName 'blank' -TemplateVersion 'v1'
             #} | Should -Not -Throw
-            Assert-MockCalled Write-Error -Scope It -Exactly -Times 0
+            Should -Invoke Write-Error -Scope It -Exactly -Times 0
         }
         It 'Should return config' {
             Mock Write-Error {}
@@ -54,7 +54,7 @@ Describe 'New-ConfigDomain' {
             $config.Platform | Should -Not -BeNullOrEmpty
             $config.Application | Should -Not -BeNullOrEmpty
             $config.Domain | Should -Not -BeNullOrEmpty
-            Assert-MockCalled Write-Error -Scope It -Exactly -Times 0
+            Should -Invoke Write-Error -Scope It -Exactly -Times 0
         }
     }
 

--- a/CDFModule/Public/func_New-ConfigPlatform.Tests.ps1
+++ b/CDFModule/Public/func_New-ConfigPlatform.Tests.ps1
@@ -29,14 +29,14 @@ Describe 'New-ConfigPlatform' {
         It 'Should create new runtime config' {
             Mock Write-Error {}
             { New-ConfigPlatform -TemplateName blank -TemplateVersion v1 } | Should -Not -Throw
-            Assert-MockCalled Write-Error -Scope It -Exactly -Times 0
+            Should -Invoke Write-Error -Scope It -Exactly -Times 0
         }
         It 'Should return config' {
             Mock Write-Error {}
             $config = Get-ConfigPlatform
             $config | Should -Not -BeNullOrEmpty
             $config.Platform | Should -Not -BeNullOrEmpty
-            Assert-MockCalled Write-Error -Scope It -Exactly -Times 0
+            Should -Invoke Write-Error -Scope It -Exactly -Times 0
         }
     }
 
@@ -74,7 +74,7 @@ Describe 'New-ConfigPlatform' {
     #             $config.Platform.ResourceNames | Should -BeNullOrEmpty
     #             $config.Platform.NetworkConfig | Should -BeNullOrEmpty
     #             $config.Platform.AccessControl | Should -BeNullOrEmpty
-    #             Assert-MockCalled Write-Error -Scope It -Exactly -Times 0
+    #             Should -Invoke Write-Error -Scope It -Exactly -Times 0
     #         }
     #         It 'Should return correct config from deployment' {
     #             Mock Write-Error {}
@@ -93,9 +93,9 @@ Describe 'New-ConfigPlatform' {
     #             $config.Platform.NetworkConfig | Should -BeNullOrEmpty
     #             $config.Platform.AccessControl | Should -BeNullOrEmpty
 
-    #             Assert-MockCalled Write-Error -Scope It -Exactly -Times 0
-    #             Assert-MockCalled Get-AzureContext -Scope It -Exactly -Times 1
-    #             Assert-MockCalled Get-AzSubscriptionDeployment -Scope It -Exactly -Times 1
+    #             Should -Invoke Write-Error -Scope It -Exactly -Times 0
+    #             Should -Invoke Get-AzureContext -Scope It -Exactly -Times 1
+    #             Should -Invoke Get-AzSubscriptionDeployment -Scope It -Exactly -Times 1
     #         }
 
     #         It 'Should write error configuration not complete' {
@@ -110,7 +110,7 @@ Describe 'New-ConfigPlatform' {
     #             {
     #                 Get-ConfigPlatform -Deployed -Region westeurope -PlatformId test -InstanceId 01 -EnvDefinitionId local
     #             } | Should -Not -Throw
-    #             Assert-MockCalled Write-Error -Scope It -Exactly -Times 1
+    #             Should -Invoke Write-Error -Scope It -Exactly -Times 1
     #         }
 
     #         It 'Should return from file with warning on unsuccessful deployment status' {
@@ -126,8 +126,8 @@ Describe 'New-ConfigPlatform' {
     #             {
     #                 Get-ConfigPlatform -Deployed -Region westeurope -PlatformId test -InstanceId 01 -EnvDefinitionId local
     #             } | Should -Not -Throw
-    #             Assert-MockCalled Write-Error -Scope It -Exactly -Times 0
-    #             Assert-MockCalled Write-Warning -Scope It -Exactly -Times 2
+    #             Should -Invoke Write-Error -Scope It -Exactly -Times 0
+    #             Should -Invoke Write-Warning -Scope It -Exactly -Times 2
     #         }
     #     }
 
@@ -184,7 +184,7 @@ Describe 'New-ConfigPlatform' {
     #             $config.Platform.AccessControl.serviceBusRBAC | Should -BeNullOrEmpty
     #             $config.Platform.AccessControl.containerRegistryRBAC  | Should -BeNullOrEmpty
 
-    #             Assert-MockCalled Write-Error -Scope It -Exactly -Times 0
+    #             Should -Invoke Write-Error -Scope It -Exactly -Times 0
     #         }
 
     #         It 'Should return correct config from files for uat/westeurope' {
@@ -233,7 +233,7 @@ Describe 'New-ConfigPlatform' {
     #             $config.Platform.AccessControl.serviceBusRBAC | Should -BeNullOrEmpty
     #             $config.Platform.AccessControl.containerRegistryRBAC  | Should -BeNullOrEmpty
 
-    #             Assert-MockCalled Write-Error -Scope It -Exactly -Times 0
+    #             Should -Invoke Write-Error -Scope It -Exactly -Times 0
     #         }
 
     #         It 'Should return correct config from deployment' {
@@ -257,10 +257,10 @@ Describe 'New-ConfigPlatform' {
 
     #             # Write-Verbose "Loading enterprise spoke network configuration"
 
-    #             Assert-MockCalled Write-Verbose -Scope It -Exactly -Times 4
-    #             Assert-MockCalled Write-Error -Scope It -Exactly -Times 0
-    #             Assert-MockCalled Get-AzureContext -Scope It -Exactly -Times 1
-    #             Assert-MockCalled Get-AzSubscriptionDeployment -Scope It -Exactly -Times 1
+    #             Should -Invoke Write-Verbose -Scope It -Exactly -Times 4
+    #             Should -Invoke Write-Error -Scope It -Exactly -Times 0
+    #             Should -Invoke Get-AzureContext -Scope It -Exactly -Times 1
+    #             Should -Invoke Get-AzSubscriptionDeployment -Scope It -Exactly -Times 1
     #         }
     #     }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Test suite migrated from the deprecated Pester v4 `Assert-MockCalled` to `Should -Invoke`; CI now runs on Pester 6 (the unbounded 5.x install began pulling Pester 6.0.0, which removed `Assert-MockCalled`)
 - `Select-AzSubscription` replaced with the supported `Set-AzContext`, for Az PowerShell 16.0 (PR #75)
 - Module loader and release packaging now exclude `*.Tests.ps1`, so co-located tests are neither imported at runtime nor published to the gallery (PR #67)
 - `Get-Config` resolves its config schema via `$PSScriptRoot` (works under module import and dot-source) and no longer hard-fails when the module is not formally loaded (PR #71)

--- a/tools/Invoke-Tests.ps1
+++ b/tools/Invoke-Tests.ps1
@@ -2,8 +2,8 @@
 .SYNOPSIS
     Runs the CDFModule Pester test suite.
 .DESCRIPTION
-    Thin wrapper around Pester 5 used both locally and in CI. Discovers
-    co-located *.Tests.ps1 files under the module path.
+    Thin wrapper around Pester (5.5+ or 6) used both locally and in CI.
+    Discovers co-located *.Tests.ps1 files under the module path.
 .EXAMPLE
     ./build/Invoke-Tests.ps1
 .EXAMPLE


### PR DESCRIPTION
Stacked on #83 (the temporary Pester 5.x pin) — GitHub retargets this to `main` automatically once #83 merges.

## What

Pester 6.0.0 removed the deprecated v4 `Assert-MockCalled`. This migrates all mock-call assertions to the Pester 5+/6 form `Should -Invoke` and moves CI onto Pester 6:

- 9 test files: `Assert-MockCalled X …` → `Should -Invoke X …` (identical positional command name and `-Scope`/`-Exactly`/`-Times`/`-ParameterFilter` switches; 57 call sites incl. commented-out ones, so the deprecated command is fully purged)
- CI `Install-Module Pester` → `-MinimumVersion 6.0.0`
- `tools/Invoke-Tests.ps1`: keeps a permissive `5.5+` floor (Should -Invoke works on both) — only the doc comment updated

## Verification

Ran the suite locally against **Pester 6.0.0**: **75/75 pass, 0 failed**. The full configuration API (`New-PesterConfiguration`, `Run.Path`, `Run.Throw`, `Run.PassThru`, `TestResult`) works unchanged on 6 — no other v6 breaking changes surfaced.

## Relationship to #83

#83 pins CI to 5.x as an immediate green-restore. This PR is the durable fix and supersedes that pin (flips the same workflow line to Pester 6). Merge #83 first, then this.